### PR TITLE
Simplify ticks, as the value is a constant

### DIFF
--- a/ticks.go
+++ b/ticks.go
@@ -1,10 +1,5 @@
 package cgroups
 
-/*
-#include <unistd.h>
-*/
-import "C"
-
 func getClockTicks() uint64 {
-	return uint64(C.sysconf(C._SC_CLK_TCK))
+	return 100
 }


### PR DESCRIPTION
See for example in the Musl libc source code https://git.musl-libc.org/cgit/musl/tree/src/conf/sysconf.c#n29

This removes another cgo dependency in `containerd`.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>