### PR TITLE
Make Travis use Prometheus 0.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: go
 go:
     - 1.7.x
 
+install:
+    - mkdir -p $GOPATH/src/github.com/prometheus $GOPATH/src/github.com/opencontainers
+    - cd $GOPATH/src/github.com/prometheus && git clone https://github.com/prometheus/client_golang.git && cd client_golang && git checkout v0.8.0
+    - cd $GOPATH/src/github.com/opencontainers && git clone https://github.com/opencontainers/runtime-spec && cd runtime-spec && git checkout v1.0.0-rc5
+    - cd $GOPATH/src/github.com/containerd/cgroups
+    - go get -t ./...
+
 script:
     - go test -race -coverprofile=coverage.txt -covermode=atomic
 


### PR DESCRIPTION
Otherwise build will fail with Prometheus master

Also had to pin runtime spec until we update to the next rc.

replaces #13

Signed-off-by: Justin Cormack <justin.cormack@docker.com>