### PR TITLE
Extend README with IgnoreNotExists example

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ processes, err := control.Processes(cgroups.Devices, recursive)
 stats, err := control.Stat()
 ```
 
+By adding `cgroups.IgnoreNotExist` all non-existent files will be ignored, e.g. swap memory stats without swap enabled
+```go
+stats, err := control.Stat(cgroups.IgnoreNotExist)
+```
+
 ### Move process across cgroups
 
 This allows you to take processes from one cgroup and move them to another.


### PR DESCRIPTION
I've just hit the "bug" https://github.com/containerd/cgroups/issues/5. You had plans to update documentation to prevent confusion, but it seems you had no time to do that. 

This PR should address missing example of ignore missing error handling. 