### PR TITLE
Write freezer state after each check

### DIFF
--- a/freezer.go
+++ b/freezer.go
@@ -26,16 +26,10 @@ func (f *freezerController) Path(path string) string {
 }
 
 func (f *freezerController) Freeze(path string) error {
-	if err := f.changeState(path, Frozen); err != nil {
-		return err
-	}
 	return f.waitState(path, Frozen)
 }
 
 func (f *freezerController) Thaw(path string) error {
-	if err := f.changeState(path, Thawed); err != nil {
-		return err
-	}
 	return f.waitState(path, Thawed)
 }
 
@@ -57,6 +51,9 @@ func (f *freezerController) state(path string) (State, error) {
 
 func (f *freezerController) waitState(path string, state State) error {
 	for {
+		if err := f.changeState(path, state); err != nil {
+			return err
+		}
 		current, err := f.state(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
This writes the current state after each check to make sure any new
additional processes to the cgroup are in the correct state.

ref: https://github.com/opencontainers/runc/issues/1609

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>