### PR TITLE
Pass proper close-on-exec flags with eventfd()

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -160,7 +160,7 @@ func (m *memoryController) OOMEventFD(path string) (uintptr, error) {
 		return 0, err
 	}
 	defer f.Close()
-	fd, _, serr := unix.RawSyscall(unix.SYS_EVENTFD2, 0, unix.FD_CLOEXEC, 0)
+	fd, _, serr := unix.RawSyscall(unix.SYS_EVENTFD2, 0, unix.EFD_CLOEXEC, 0)
 	if serr != 0 {
 		return 0, serr
 	}


### PR DESCRIPTION
Signed-off-by: Kenfe-Mickael Laventure <mickael.laventure@gmail.com>