### PR TITLE
Fix tests when there's no cgroup hierarchy mounted

### DIFF
--- a/paths_test.go
+++ b/paths_test.go
@@ -19,6 +19,12 @@ func TestStaticPath(t *testing.T) {
 }
 
 func TestSelfPath(t *testing.T) {
+	_, err := v1MountPoint()
+	if err == ErrMountPointNotExist {
+		t.Skip("skipping test that requires cgroup hierarchy")
+	} else if err != nil {
+		t.Fatal(err)
+	}
 	paths, err := parseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +41,12 @@ func TestSelfPath(t *testing.T) {
 }
 
 func TestPidPath(t *testing.T) {
+	_, err := v1MountPoint()
+	if err == ErrMountPointNotExist {
+		t.Skip("skipping test that requires cgroup hierarchy")
+	} else if err != nil {
+		t.Fatal(err)
+	}
 	paths, err := parseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This happens when building the package in a chroot. To be more accurate, when building the package for Debian and using pbuilder.