### PR TITLE
Add support for rdma cgroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 
 install:
     - mkdir -p $GOPATH/src/github.com/prometheus $GOPATH/src/github.com/opencontainers
-    - cd $GOPATH/src/github.com/opencontainers && git clone https://github.com/opencontainers/runtime-spec && cd runtime-spec && git checkout 96de01bbb42c7af89bff100e10a9f0fb62e75bfb
+    - cd $GOPATH/src/github.com/opencontainers && git clone https://github.com/opencontainers/runtime-spec && cd runtime-spec && git checkout fa4b36aa9c99e00c2ef7b5c0013c84100ede5f4e
     - cd $GOPATH/src/github.com/containerd/cgroups
     - go get -t ./...
 

--- a/metrics.pb.go
+++ b/metrics.pb.go
@@ -19,6 +19,8 @@
 		MemoryEntry
 		BlkIOStat
 		BlkIOEntry
+		RdmaStat
+		RdmaEntry
 */
 package cgroups
 
@@ -49,6 +51,7 @@ type Metrics struct {
 	CPU     *CPUStat       `protobuf:"bytes,3,opt,name=cpu" json:"cpu,omitempty"`
 	Memory  *MemoryStat    `protobuf:"bytes,4,opt,name=memory" json:"memory,omitempty"`
 	Blkio   *BlkIOStat     `protobuf:"bytes,5,opt,name=blkio" json:"blkio,omitempty"`
+	Rdma    *RdmaStat      `protobuf:"bytes,6,opt,name=rdma" json:"rdma,omitempty"`
 }
 
 func (m *Metrics) Reset()                    { *m = Metrics{} }
@@ -187,6 +190,25 @@ func (m *BlkIOEntry) Reset()                    { *m = BlkIOEntry{} }
 func (*BlkIOEntry) ProtoMessage()               {}
 func (*BlkIOEntry) Descriptor() ([]byte, []int) { return fileDescriptorMetrics, []int{9} }
 
+type RdmaStat struct {
+	Current []*RdmaEntry `protobuf:"bytes,1,rep,name=current" json:"current,omitempty"`
+	Limit   []*RdmaEntry `protobuf:"bytes,2,rep,name=limit" json:"limit,omitempty"`
+}
+
+func (m *RdmaStat) Reset()                    { *m = RdmaStat{} }
+func (*RdmaStat) ProtoMessage()               {}
+func (*RdmaStat) Descriptor() ([]byte, []int) { return fileDescriptorMetrics, []int{10} }
+
+type RdmaEntry struct {
+	Device     string `protobuf:"bytes,1,opt,name=device,proto3" json:"device,omitempty"`
+	HcaHandles uint32 `protobuf:"varint,2,opt,name=hca_handles,json=hcaHandles,proto3" json:"hca_handles,omitempty"`
+	HcaObjects uint32 `protobuf:"varint,3,opt,name=hca_objects,json=hcaObjects,proto3" json:"hca_objects,omitempty"`
+}
+
+func (m *RdmaEntry) Reset()                    { *m = RdmaEntry{} }
+func (*RdmaEntry) ProtoMessage()               {}
+func (*RdmaEntry) Descriptor() ([]byte, []int) { return fileDescriptorMetrics, []int{11} }
+
 func init() {
 	proto.RegisterType((*Metrics)(nil), "io.containerd.cgroups.v1.Metrics")
 	proto.RegisterType((*HugetlbStat)(nil), "io.containerd.cgroups.v1.HugetlbStat")
@@ -198,6 +220,8 @@ func init() {
 	proto.RegisterType((*MemoryEntry)(nil), "io.containerd.cgroups.v1.MemoryEntry")
 	proto.RegisterType((*BlkIOStat)(nil), "io.containerd.cgroups.v1.BlkIOStat")
 	proto.RegisterType((*BlkIOEntry)(nil), "io.containerd.cgroups.v1.BlkIOEntry")
+	proto.RegisterType((*RdmaStat)(nil), "io.containerd.cgroups.v1.RdmaStat")
+	proto.RegisterType((*RdmaEntry)(nil), "io.containerd.cgroups.v1.RdmaEntry")
 }
 func (m *Metrics) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
@@ -265,6 +289,16 @@ func (m *Metrics) MarshalTo(dAtA []byte) (int, error) {
 			return 0, err
 		}
 		i += n4
+	}
+	if m.Rdma != nil {
+		dAtA[i] = 0x32
+		i++
+		i = encodeVarintMetrics(dAtA, i, uint64(m.Rdma.Size()))
+		n5, err := m.Rdma.MarshalTo(dAtA[i:])
+		if err != nil {
+			return 0, err
+		}
+		i += n5
 	}
 	return i, nil
 }
@@ -732,6 +766,7 @@ func (m *MemoryEntry) MarshalTo(dAtA []byte) (int, error) {
 	_ = i
 	var l int
 	_ = l
+
 	if m.Limit != 0 {
 		dAtA[i] = 0x8
 		i++
@@ -914,6 +949,82 @@ func (m *BlkIOEntry) MarshalTo(dAtA []byte) (int, error) {
 	return i, nil
 }
 
+func (m *RdmaStat) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RdmaStat) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Current) > 0 {
+		for _, msg := range m.Current {
+			dAtA[i] = 0xa
+			i++
+			i = encodeVarintMetrics(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	if len(m.Limit) > 0 {
+		for _, msg := range m.Limit {
+			dAtA[i] = 0x12
+			i++
+			i = encodeVarintMetrics(dAtA, i, uint64(msg.Size()))
+			n, err := msg.MarshalTo(dAtA[i:])
+			if err != nil {
+				return 0, err
+			}
+			i += n
+		}
+	}
+	return i, nil
+}
+
+func (m *RdmaEntry) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalTo(dAtA)
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *RdmaEntry) MarshalTo(dAtA []byte) (int, error) {
+	var i int
+	_ = i
+	var l int
+	_ = l
+	if len(m.Device) > 0 {
+		dAtA[i] = 0xa
+		i++
+		i = encodeVarintMetrics(dAtA, i, uint64(len(m.Device)))
+		i += copy(dAtA[i:], m.Device)
+	}
+	if m.HcaHandles != 0 {
+		dAtA[i] = 0x10
+		i++
+		i = encodeVarintMetrics(dAtA, i, uint64(m.HcaHandles))
+	}
+	if m.HcaObjects != 0 {
+		dAtA[i] = 0x18
+		i++
+		i = encodeVarintMetrics(dAtA, i, uint64(m.HcaObjects))
+	}
+	return i, nil
+}
+
 func encodeFixed64Metrics(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	dAtA[offset+1] = uint8(v >> 8)
@@ -964,6 +1075,10 @@ func (m *Metrics) Size() (n int) {
 	}
 	if m.Blkio != nil {
 		l = m.Blkio.Size()
+		n += 1 + l + sovMetrics(uint64(l))
+	}
+	if m.Rdma != nil {
+		l = m.Rdma.Size()
 		n += 1 + l + sovMetrics(uint64(l))
 	}
 	return n
@@ -1264,6 +1379,40 @@ func (m *BlkIOEntry) Size() (n int) {
 	return n
 }
 
+func (m *RdmaStat) Size() (n int) {
+	var l int
+	_ = l
+	if len(m.Current) > 0 {
+		for _, e := range m.Current {
+			l = e.Size()
+			n += 1 + l + sovMetrics(uint64(l))
+		}
+	}
+	if len(m.Limit) > 0 {
+		for _, e := range m.Limit {
+			l = e.Size()
+			n += 1 + l + sovMetrics(uint64(l))
+		}
+	}
+	return n
+}
+
+func (m *RdmaEntry) Size() (n int) {
+	var l int
+	_ = l
+	l = len(m.Device)
+	if l > 0 {
+		n += 1 + l + sovMetrics(uint64(l))
+	}
+	if m.HcaHandles != 0 {
+		n += 1 + sovMetrics(uint64(m.HcaHandles))
+	}
+	if m.HcaObjects != 0 {
+		n += 1 + sovMetrics(uint64(m.HcaObjects))
+	}
+	return n
+}
+
 func sovMetrics(x uint64) (n int) {
 	for {
 		n++
@@ -1287,6 +1436,7 @@ func (this *Metrics) String() string {
 		`CPU:` + strings.Replace(fmt.Sprintf("%v", this.CPU), "CPUStat", "CPUStat", 1) + `,`,
 		`Memory:` + strings.Replace(fmt.Sprintf("%v", this.Memory), "MemoryStat", "MemoryStat", 1) + `,`,
 		`Blkio:` + strings.Replace(fmt.Sprintf("%v", this.Blkio), "BlkIOStat", "BlkIOStat", 1) + `,`,
+		`Rdma:` + strings.Replace(fmt.Sprintf("%v", this.Rdma), "RdmaStat", "RdmaStat", 1) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -1440,6 +1590,29 @@ func (this *BlkIOEntry) String() string {
 	}, "")
 	return s
 }
+func (this *RdmaStat) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RdmaStat{`,
+		`Current:` + strings.Replace(fmt.Sprintf("%v", this.Current), "RdmaEntry", "RdmaEntry", 1) + `,`,
+		`Limit:` + strings.Replace(fmt.Sprintf("%v", this.Limit), "RdmaEntry", "RdmaEntry", 1) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *RdmaEntry) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&RdmaEntry{`,
+		`Device:` + fmt.Sprintf("%v", this.Device) + `,`,
+		`HcaHandles:` + fmt.Sprintf("%v", this.HcaHandles) + `,`,
+		`HcaObjects:` + fmt.Sprintf("%v", this.HcaObjects) + `,`,
+		`}`,
+	}, "")
+	return s
+}
 func valueToStringMetrics(v interface{}) string {
 	rv := reflect.ValueOf(v)
 	if rv.IsNil() {
@@ -1451,6 +1624,7 @@ func valueToStringMetrics(v interface{}) string {
 func (m *Metrics) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
+
 	for iNdEx < l {
 		preIndex := iNdEx
 		var wire uint64
@@ -1637,6 +1811,39 @@ func (m *Metrics) Unmarshal(dAtA []byte) error {
 				m.Blkio = &BlkIOStat{}
 			}
 			if err := m.Blkio.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 6:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rdma", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetrics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMetrics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Rdma == nil {
+				m.Rdma = &RdmaStat{}
+			}
+			if err := m.Rdma.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex
@@ -3656,6 +3863,236 @@ func (m *BlkIOEntry) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *RdmaStat) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMetrics
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RdmaStat: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RdmaStat: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Current", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetrics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMetrics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Current = append(m.Current, &RdmaEntry{})
+			if err := m.Current[len(m.Current)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Limit", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetrics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= (int(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthMetrics
+			}
+			postIndex := iNdEx + msglen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Limit = append(m.Limit, &RdmaEntry{})
+			if err := m.Limit[len(m.Limit)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMetrics(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMetrics
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *RdmaEntry) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMetrics
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= (uint64(b) & 0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: RdmaEntry: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: RdmaEntry: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Device", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetrics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= (uint64(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMetrics
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Device = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HcaHandles", wireType)
+			}
+			m.HcaHandles = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetrics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.HcaHandles |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 3:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field HcaObjects", wireType)
+			}
+			m.HcaObjects = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMetrics
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.HcaObjects |= (uint32(b) & 0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMetrics(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if skippy < 0 {
+				return ErrInvalidLengthMetrics
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+
 func skipMetrics(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0

--- a/metrics.pb.txt
+++ b/metrics.pb.txt
@@ -47,6 +47,14 @@ file {
       type_name: ".io.containerd.cgroups.v1.BlkIOStat"
       json_name: "blkio"
     }
+    field {
+      name: "rdma"
+      number: 6
+      label: LABEL_OPTIONAL
+      type: TYPE_MESSAGE
+      type_name: ".io.containerd.cgroups.v1.RdmaStat"
+      json_name: "rdma"
+    }
   }
   message_type {
     name: "HugetlbStat"
@@ -581,6 +589,49 @@ file {
       label: LABEL_OPTIONAL
       type: TYPE_UINT64
       json_name: "value"
+    }
+  }
+  message_type {
+    name: "RdmaStat"
+    field {
+      name: "current"
+      number: 1
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".io.containerd.cgroups.v1.RdmaEntry"
+      json_name: "current"
+    }
+    field {
+      name: "limit"
+      number: 2
+      label: LABEL_REPEATED
+      type: TYPE_MESSAGE
+      type_name: ".io.containerd.cgroups.v1.RdmaEntry"
+      json_name: "limit"
+    }
+  }
+  message_type {
+    name: "RdmaEntry"
+    field {
+      name: "device"
+      number: 2
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "device"
+    }
+    field {
+      name: "hca_handles"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "hca_handles"
+    }
+    field {
+      name: "hca_objects"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_UINT64
+      json_name: "hca_objects"
     }
   }
   syntax: "proto3"

--- a/metrics.proto
+++ b/metrics.proto
@@ -10,6 +10,7 @@ message Metrics {
 	CPUStat cpu = 3 [(gogoproto.customname) = "CPU"];
 	MemoryStat memory = 4;
 	BlkIOStat blkio = 5;
+	RdmaStat rdma = 6;
 }
 
 message HugetlbStat {
@@ -108,4 +109,15 @@ message BlkIOEntry {
 	uint64 major = 3;
 	uint64 minor = 4;
 	uint64 value = 5;
+}
+
+message RdmaStat {
+	repeated RdmaEntry current = 1;
+	repeated RdmaEntry limit = 2;
+}
+
+message RdmaEntry {
+	string device = 1;
+	uint32 hca_handles = 2;
+	uint32 hca_objects = 3;
 }

--- a/rdma.go
+++ b/rdma.go
@@ -1,0 +1,137 @@
+package cgroups
+
+import (
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+type rdmaController struct {
+	root string
+}
+
+func (p *rdmaController) Name() Name {
+	return Rdma
+}
+
+func (p *rdmaController) Path(path string) string {
+	return filepath.Join(p.root, path)
+}
+
+func NewRdma(root string) *rdmaController {
+	return &rdmaController{
+		root: filepath.Join(root, string(Rdma)),
+	}
+}
+
+func createCmdString(device string, limits *specs.LinuxRdma) string {
+	var cmdString string
+
+	cmdString = device
+	if limits.HcaHandles != nil {
+		cmdString = cmdString + " " + "hca_handle=" + strconv.FormatUint(uint64(*limits.HcaHandles), 10)
+	}
+
+	if limits.HcaObjects != nil {
+		cmdString = cmdString + " " + "hca_object=" + strconv.FormatUint(uint64(*limits.HcaObjects), 10)
+	}
+	return cmdString
+}
+
+func (p *rdmaController) Create(path string, resources *specs.LinuxResources) error {
+	if err := os.MkdirAll(p.Path(path), defaultDirPerm); err != nil {
+		return err
+	}
+
+	for device, limit := range resources.Rdma {
+		if device != "" && (limit.HcaHandles != nil || limit.HcaObjects != nil) {
+			return ioutil.WriteFile(
+				filepath.Join(p.Path(path), "rdma.max"),
+				[]byte(createCmdString(device, &limit)),
+				defaultFilePerm,
+			)
+		}
+	}
+	return nil
+}
+
+func (p *rdmaController) Update(path string, resources *specs.LinuxResources) error {
+	return p.Create(path, resources)
+}
+
+func parseRdmaKV(raw string, entry *RdmaEntry) {
+	var value uint64
+	var err error
+
+	parts := strings.Split(raw, "=")
+	switch len(parts) {
+	case 2:
+		if parts[1] == "max" {
+			value = math.MaxUint32
+		} else {
+			value, err = parseUint(parts[1], 10, 32)
+			if err != nil {
+				return
+			}
+		}
+		if parts[0] == "hca_handle" {
+			entry.HcaHandles = uint32(value)
+		} else if parts[0] == "hca_object" {
+			entry.HcaObjects = uint32(value)
+		}
+	}
+}
+
+func toRdmaEntry(strEntries []string) []*RdmaEntry {
+	var rdmaEntries []*RdmaEntry
+	for i := range strEntries {
+		parts := strings.Fields(strEntries[i])
+		switch len(parts) {
+		case 3:
+			entry := new(RdmaEntry)
+			entry.Device = parts[0]
+			parseRdmaKV(parts[1], entry)
+			parseRdmaKV(parts[2], entry)
+
+			rdmaEntries = append(rdmaEntries, entry)
+		default:
+			continue
+		}
+	}
+	return rdmaEntries
+}
+
+func (p *rdmaController) Stat(path string, stats *Metrics) error {
+
+	currentData, err := ioutil.ReadFile(filepath.Join(p.Path(path), "rdma.current"))
+	if err != nil {
+		return err
+	}
+	currentPerDevices := strings.Split(string(currentData), "\n")
+
+	maxData, err := ioutil.ReadFile(filepath.Join(p.Path(path), "rdma.max"))
+	if err != nil {
+		return err
+	}
+	maxPerDevices := strings.Split(string(maxData), "\n")
+
+	// If device got removed between reading two files, ignore returning
+	// stats.
+	if len(currentPerDevices) != len(maxPerDevices) {
+		return nil
+	}
+
+	currentEntries := toRdmaEntry(currentPerDevices)
+	maxEntries := toRdmaEntry(maxPerDevices)
+
+	stats.Rdma = &RdmaStat{
+		Current: currentEntries,
+		Limit:   maxEntries,
+	}
+	return nil
+}

--- a/subsystem.go
+++ b/subsystem.go
@@ -22,6 +22,7 @@ const (
 	Cpuacct   Name = "cpuacct"
 	Memory    Name = "memory"
 	Blkio     Name = "blkio"
+	Rdma      Name = "rdma"
 )
 
 // Subsystems returns a complete list of the default cgroups
@@ -39,6 +40,7 @@ func Subsystems() []Name {
 		Cpuacct,
 		Memory,
 		Blkio,
+		Rdma,
 	}
 	if !isUserNS {
 		n = append(n, Devices)

--- a/utils.go
+++ b/utils.go
@@ -64,6 +64,7 @@ func defaults(root string) ([]Subsystem, error) {
 		NewCpuacct(root),
 		NewMemory(root),
 		NewBlkio(root),
+		NewRdma(root),
 	}
 	// only add the devices cgroup if we are not in a user namespace
 	// because modifications are not allowed


### PR DESCRIPTION
RDMA controller/cgroup support is added with Linux kernel 4.11.
It allows to limit RDMA/IB specific resources.
It is described at [1].

runc-spec update is already merged last week in PR [2].

Add support to set rdma cgroup parameters and read statistics.

[1] https://www.kernel.org/doc/Documentation/cgroup-v1/rdma.txt
[2] https://github.com/opencontainers/runtime-spec/pull/942

Signed-off-by: Parav Pandit <parav@mellanox.com>