### PR TITLE
[release/1.0] Fix incorrect use of OCI runtime specs-go cgroup dev types

### DIFF
--- a/devices.go
+++ b/devices.go
@@ -58,11 +58,11 @@ func (d *devicesController) Update(path string, resources *specs.LinuxResources)
 }
 
 func deviceString(device specs.LinuxDeviceCgroup) string {
-	return fmt.Sprintf("%c %s:%s %s",
-		&device.Type,
+	return fmt.Sprintf("%s %s:%s %s",
+		device.Type,
 		deviceNumber(device.Major),
 		deviceNumber(device.Minor),
-		&device.Access,
+		device.Access,
 	)
 }
 


### PR DESCRIPTION
Cherry pick OCI runtime spec CgroupLinuxDevice type mismatches with `fmt.Sprintf`

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>