### PR TITLE
[release/1.0] Update Go version in travis on the 1.0.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
-    - 1.8.x
+    - 1.10.x
+    - tip
 
 install:
     - mkdir -p $GOPATH/src/github.com/prometheus $GOPATH/src/github.com/opencontainers


### PR DESCRIPTION
To match what was already done in master for containerd/cgroups. Given
we branched prior to this change in master, we need to update here as
well.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>