### PR TITLE
Remove call to unitName

### DIFF
--- a/systemd.go
+++ b/systemd.go
@@ -54,7 +54,7 @@ func Slice(slice, name string) Path {
 		slice = defaultSlice
 	}
 	return func(subsystem Name) (string, error) {
-		return filepath.Join(slice, unitName(name)), nil
+		return filepath.Join(slice, name), nil
 	}
 }
 


### PR DESCRIPTION
- Calling unitName incorrectly appends -slice onto the end of the slice cgroup we are looking for
- Tested and can't see any obvious side effects by removing this call
- Fixes #47 