### PR TITLE
Bugfix: can't write to cpuset cgroup

### DIFF
--- a/cpuset.go
+++ b/cpuset.go
@@ -57,21 +57,21 @@ func (c *cpusetController) Create(path string, resources *specs.LinuxResources) 
 	if resources.CPU != nil {
 		for _, t := range []struct {
 			name  string
-			value *string
+			value string
 		}{
 			{
 				name:  "cpus",
-				value: &resources.CPU.Cpus,
+				value: resources.CPU.Cpus,
 			},
 			{
 				name:  "mems",
-				value: &resources.CPU.Mems,
+				value: resources.CPU.Mems,
 			},
 		} {
-			if t.value != nil {
+			if t.value != "" {
 				if err := ioutil.WriteFile(
 					filepath.Join(c.Path(path), fmt.Sprintf("cpuset.%s", t.name)),
-					[]byte(*t.value),
+					[]byte(t.value),
 					defaultFilePerm,
 				); err != nil {
 					return err


### PR DESCRIPTION
Using linux resource in spec:

```
"resources": {
    "cpu": {
        "period": 100000,
        "quota": 40000
    },
...
}
```

In this case, `resources.CPU` != nil but `resources.CPU.Cpus` and `resources.CPU.Mems`
are empty strings, `cgroups` lib will write "" to cpuset.cpus and cpuset.mems in
Cpuset group, then no process can be written in this cgroup any more.

In this case, empty value means copying from parent but doesn't mean no CPU can
be used in this cgroup.

Signed-off-by: Wei Zhang <zhangwei555@huawei.com>