### PR TITLE
Add project references and use common project travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,15 @@ install:
     - cd $GOPATH/src/github.com/opencontainers && git clone https://github.com/opencontainers/runtime-spec && cd runtime-spec && git checkout fa4b36aa9c99e00c2ef7b5c0013c84100ede5f4e
     - cd $GOPATH/src/github.com/containerd/cgroups
     - go get -t ./...
+    - go get -u github.com/vbatts/git-validation
+    - go get -u github.com/kunalkushwaha/ltag
+
+before_script:
+    - pushd ..; git clone https://github.com/containerd/project; popd
 
 script:
+    - DCO_VERBOSITY=-q ../project/script/validate/dco
+    - ../project/script/validate/fileheader ../project/
     - go test -race -coverprofile=coverage.txt -covermode=atomic
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -110,3 +110,14 @@ err := control.MoveTo(destination)
 ```go
 subCgroup, err := control.New("child", resources)
 ```
+
+## Project details
+
+Cgroups is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).
+As a containerd sub-project, you will find the:
+
+ * [Project governance](https://github.com/containerd/project/blob/master/GOVERNANCE.md),
+ * [Maintainers](https://github.com/containerd/project/blob/master/MAINTAINERS),
+ * and [Contributing guidelines](https://github.com/containerd/project/blob/master/CONTRIBUTING.md)
+
+information in our [`containerd/project`](https://github.com/containerd/project) repository.


### PR DESCRIPTION
Add in DCO check and file header check; add project boilerplate to
README with governance, maintainers, and contributing guidelines.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>