### PR TITLE
Fix gofmt of systemd.go

### DIFF
--- a/systemd.go
+++ b/systemd.go
@@ -34,7 +34,7 @@ const (
 
 var (
 	canDelegate bool
-	once sync.Once
+	once        sync.Once
 )
 
 func Systemd() ([]Subsystem, error) {


### PR DESCRIPTION
This file had one non-gofmt'd line.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>