### PR TITLE
Add go-systemd dep for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,12 @@ go:
     - tip
 
 install:
-    - mkdir -p $GOPATH/src/github.com/prometheus $GOPATH/src/github.com/opencontainers
+     - mkdir -p $GOPATH/src/github.com/prometheus $GOPATH/src/github.com/opencontainers $GOPATH/src/github.com/coreos $GOPATH/src/github.com/godbus 
     - cd $GOPATH/src/github.com/opencontainers && git clone https://github.com/opencontainers/runtime-spec && cd runtime-spec && git checkout fa4b36aa9c99e00c2ef7b5c0013c84100ede5f4e
+    - cd $GOPATH/src/github.com/coreos && git clone https://github.com/coreos/go-systemd && cd go-systemd && git checkout 48702e0da86bd25e76cfef347e2adeb434a0d0a6
+    - cd $GOPATH/src/github.com/godbus && git clone https://github.com/godbus/dbus && cd dbus && git checkout c7fdd8b5cd55e87b4e1f4e372cdb1db61dd6c66f
     - cd $GOPATH/src/github.com/containerd/cgroups
-    - go get -t ./...
+    - go get -d -t ./...
     - go get -u github.com/vbatts/git-validation
     - go get -u github.com/kunalkushwaha/ltag
 


### PR DESCRIPTION
The underlying package changed and we need to depend on a specific
version now for testing with the CI

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>