### PR TITLE
Return ErrCgroupDeleted when no subsystems

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -105,6 +105,10 @@ func Load(hierarchy Hierarchy, path Path, opts ...InitOpts) (Cgroup, error) {
 		}
 		activeSubsystems = append(activeSubsystems, s)
 	}
+	// if we do not have any active systems then the cgroup is deleted
+	if len(activeSubsystems) == 0 {
+		return nil, ErrCgroupDeleted
+	}
 	return &cgroup{
 		path:       path,
 		subsystems: activeSubsystems,


### PR DESCRIPTION
Return the error when 0 subsystems are active signaling that the cgroup
has been deleted.

Fix for: https://github.com/containerd/containerd/issues/3133

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>