### PR TITLE
Fix cgroup hugetlb size prefix for kB

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -168,7 +168,7 @@ func readTasksPids(path string, subsystem Name) ([]Task, error) {
 func hugePageSizes() ([]string, error) {
 	var (
 		pageSizes []string
-		sizeList  = []string{"B", "kB", "MB", "GB", "TB", "PB"}
+		sizeList  = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 	)
 	files, err := ioutil.ReadDir("/sys/kernel/mm/hugepages")
 	if err != nil {


### PR DESCRIPTION
Hi!

The hugetlb cgroup control files (introduced here in 2012:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=abb8206cb0773)
use "KB" and not "kB"
(https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/mm/hugetlb_cgroup.c?h=v5.0#n349).

The behavior in the kernel has not changed since the introduction, and
the current code using "kB" will therefore fail on devices with small
amounts of ram (see
kubernetes/kubernetes#77169) running a kernel
with config flag CONFIG_HUGETLBFS=y

As seen from the code in "mem_fmt" inside hugetlb_cgroup.c, only "KB",
"MB" and "GB" are used, so the others may be removed as well.

Here is a real world example of the files (aarch64) inside the
"/sys/kernel/mm/hugepages/" directory:
- "hugepages-64kB"
- "hugepages-2048kB"
- "hugepages-32768kB"
- "hugepages-1048576kB"

And the corresponding cgroup files:
- "hugetlb.64KB._____"
- "hugetlb.2MB._____"
- "hugetlb.32MB._____"
- "hugetlb.1GB._____"

Some more info can be found here: https://github.com/kubernetes/kubernetes/pull/78495 & https://github.com/opencontainers/runc/pull/2065, https://github.com/kubernetes/kubernetes/issues/77169 and https://lkml.org/lkml/2019/5/29/1008