### PR TITLE
cgroups: fix MoveTo function fail problem

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -497,6 +497,9 @@ func (c *cgroup) MoveTo(destination Cgroup) error {
 		}
 		for _, p := range processes {
 			if err := destination.Add(p); err != nil {
+				if strings.Contains(err.Error(), "no such process") {
+					continue
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
reason: there maybe some multi processes in the cgroup.procs file,if
some processes exit before call destination.Add(p), it will get the error
"no such process" which means process has exit and we just ignore this
error and continue to move left processes in cgroup.procs file.