### PR TITLE
Allow overriding the default /proc folder in blkioController

### DIFF
--- a/blkio_test.go
+++ b/blkio_test.go
@@ -49,3 +49,31 @@ func TestGetDevices(t *testing.T) {
 		t.Fatalf("expected device name %q but received %q", expected, name)
 	}
 }
+
+func TestNewBlkio(t *testing.T) {
+	const root = "/test/folder"
+	const expected = "/test/folder/blkio"
+	const expectedProc = "/proc"
+
+	ctrl := NewBlkio(root)
+	if ctrl.root != expected {
+		t.Fatalf("expected cgroups root %q but received %q", expected, ctrl.root)
+	}
+	if ctrl.procRoot != expectedProc {
+		t.Fatalf("expected proc FS root %q but received %q", expectedProc, ctrl.procRoot)
+	}
+}
+
+func TestNewBlkio_Proc(t *testing.T) {
+	const root = "/test/folder"
+	const expected = "/test/folder/blkio"
+	const expectedProc = "/test/proc"
+
+	ctrl := NewBlkio(root, ProcRoot(expectedProc))
+	if ctrl.root != expected {
+		t.Fatalf("expected cgroups root %q but received %q", expected, ctrl.root)
+	}
+	if ctrl.procRoot != expectedProc {
+		t.Fatalf("expected proc FS root %q but received %q", expectedProc, ctrl.procRoot)
+	}
+}


### PR DESCRIPTION
A host may share its `/proc` FS folder with a privileged container, mounted in an
alternative folder (e.g. `/host/proc`), as some users prefer to run their
monitoring software inside a container rather than a host process.

This patch allows overriding the default `/proc` folder to allow the blkio
Controller working inside containerized monitoring software.

The `/proc` root can be overriden via an optional function (`ProcRoot`) to
avoid introducing a new `NewBlkio` constructor or introducing breaking changes
in the current API.

Then, the `NewBlkio` constructor can be invoked as usual, or in the following
form, to override the /proc path:

```go
ctrl := NewBlkio("/sys/fs/cgroup", ProcRoot("/host/proc"))
```