### PR TITLE
Allows ignoring memory modules

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -32,14 +32,32 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func NewMemory(root string) *memoryController {
-	return &memoryController{
-		root: filepath.Join(root, string(Memory)),
+// NewMemory returns a Memory controller given the root folder of cgroups.
+// It may optionally accept other configuration options, such as IgnoreModules(...)
+func NewMemory(root string, options ...func(*memoryController)) *memoryController {
+	mc := &memoryController{
+		root:    filepath.Join(root, string(Memory)),
+		ignored: map[string]struct{}{},
+	}
+	for _, opt := range options {
+		opt(mc)
+	}
+	return mc
+}
+
+// IgnoreModules configure the memory controller to not read memory metrics for some
+// module names (e.g. passing "memsw" would avoid all the memory.memsw.* entries)
+func IgnoreModules(names ...string) func(*memoryController) {
+	return func(mc *memoryController) {
+		for _, name := range names {
+			mc.ignored[name] = struct{}{}
+		}
 	}
 }
 
 type memoryController struct {
-	root string
+	root    string
+	ignored map[string]struct{}
 }
 
 func (m *memoryController) Name() Name {
@@ -133,6 +151,9 @@ func (m *memoryController) Stat(path string, stats *v1.Metrics) error {
 			entry:  stats.Memory.KernelTCP,
 		},
 	} {
+		if _, ok := m.ignored[t.module]; ok {
+			continue
+		}
 		for _, tt := range []struct {
 			name  string
 			value *uint64

--- a/memory.go
+++ b/memory.go
@@ -55,6 +55,17 @@ func IgnoreModules(names ...string) func(*memoryController) {
 	}
 }
 
+// OptionalSwap allows the memory controller to not fail if cgroups is not accounting
+// Swap memory (there are no memory.memsw.* entries)
+func OptionalSwap() func(*memoryController) {
+	return func(mc *memoryController) {
+		_, err := os.Stat(filepath.Join(mc.root, "memory.memsw.usage_in_bytes"))
+		if os.IsNotExist(err) {
+			mc.ignored["memsw"] = struct{}{}
+		}
+	}
+}
+
 type memoryController struct {
 	root    string
 	ignored map[string]struct{}

--- a/memory_test.go
+++ b/memory_test.go
@@ -196,10 +196,10 @@ func buildMemoryMetrics(t *testing.T, modules []string, metrics []string) string
 		t.Fatal(err)
 	}
 	tmpDir := path.Join(tmpRoot, string(Memory))
-	if err := os.MkdirAll(tmpDir, os.ModeDir); err != nil {
+	if err := os.MkdirAll(tmpDir, defaultDirPerm); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(tmpDir, "memory.stat"), []byte(memoryData), 0666); err != nil {
+	if err := ioutil.WriteFile(path.Join(tmpDir, "memory.stat"), []byte(memoryData), defaultFilePerm); err != nil {
 		t.Fatal(err)
 	}
 	cnt := 0
@@ -211,7 +211,7 @@ func buildMemoryMetrics(t *testing.T, modules []string, metrics []string) string
 			} else {
 				fileName = path.Join(tmpDir, strings.Join([]string{"memory", mod, metric}, "."))
 			}
-			if err := ioutil.WriteFile(fileName, []byte(fmt.Sprintln(cnt)), 0666); err != nil {
+			if err := ioutil.WriteFile(fileName, []byte(fmt.Sprintln(cnt)), defaultFilePerm); err != nil {
 				t.Fatal(err)
 			}
 			cnt++


### PR DESCRIPTION
Some hosts may have disabled some memory modules (e.g. `memsw` metrics
are not available if the Kernel is built without the
`CONFIG_MEMCG_SWAP_ENABLED` variable. This made the memory controller
`Stat` function to not work properly, because it returns error
when a single memory entry is not available.

Even if you run `cgroups.Stat(cgroups.IgnoreNotExist)` to ignore memory
Stat errors, you won't get most of the memory metrics.

This patch adds a configuration function parameter to the `NewMemory`
constructor. This way, we don't introduce breaking changes in the
current API. You can invoke the `NewMemory` constructor as usual or
with a new optional configuration option:

```go
mem := cgroups.NewMemory(root, cgroups.IgnoreModules("memsw"))
```

If you want to let the constructor to automatically ignore `memsw` module
only if it is not available:

```go
mem := cgroups.NewMemory(root, cgroups.OptionalSwap())
```

Signed-off-by: Mario Macias <mmacias@newrelic.com>