### PR TITLE
Update doc add static path prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ err := control.MoveTo(destination)
 subCgroup, err := control.New("child", resources)
 ```
 
+### Attention
+
+All static path should not include `/sys/fs/cgroup/` prefix, it should start with your own cgroups name
+
 ## Project details
 
 Cgroups is a containerd sub-project, licensed under the [Apache 2.0 license](./LICENSE).


### PR DESCRIPTION
I use the function `cgroups.Load(cgroups.V1, cgroups.StaticPath(location))`, find that it always report that `cgroup deleted`.  I find that my location is ` /sys/fs/cgroup/cpu/kubepods.slice/kubepods-besteffort.slice/`, it start with `/sys/fs`, through the code I find that, this library will add `/sys/fs/cgroup` prefix auto. So I add the pr to make it more clearly