### PR TITLE
Added OOM notification for Memory controller

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -39,8 +39,6 @@ const (
 	controllersFile = "cgroup.controllers"
 )
 
-var oomEventCount = 0
-
 type cgValuer interface {
 	Values() []Value
 }


### PR DESCRIPTION
Partially Fixes #104 

@crosbymichael @AkihiroSuda 
So this Pr is on of the ideas I have on how we can implement `OOM notifications` in `cGroupv2`.
So, I see here at least two directions, we can implement `Inotify fd` check right here and in case if we receive `inotify` event, create new separate file for `oom's` only, and return that file `fd`.
On other hand we can delegate it to next layers(containerd etc.)
What do you think of this approach?
Signed-off-by: bpopovschi <zyqsempai@mail.ru>