### PR TITLE
v2: toggle ancestors of c.path, not c.path itself

### DIFF
--- a/cmd/cgctl/main.go
+++ b/cmd/cgctl/main.go
@@ -46,6 +46,7 @@ func main() {
 		newCommand,
 		delCommand,
 		listCommand,
+		listControllersCommand,
 		statCommand,
 	}
 	app.Before = func(clix *cli.Context) error {
@@ -76,7 +77,7 @@ var newCommand = cli.Command{
 			return err
 		}
 		if clix.Bool("enable") {
-			controllers, err := c.ListControllers()
+			controllers, err := c.RootControllers()
 			if err != nil {
 				return err
 			}
@@ -116,6 +117,26 @@ var listCommand = cli.Command{
 		}
 		for _, p := range procs {
 			fmt.Println(p)
+		}
+		return nil
+	},
+}
+
+var listControllersCommand = cli.Command{
+	Name:  "list-controllers",
+	Usage: "list controllers in a cgroup",
+	Action: func(clix *cli.Context) error {
+		path := clix.Args().First()
+		c, err := v2.LoadManager(clix.GlobalString("mountpoint"), path)
+		if err != nil {
+			return err
+		}
+		controllers, err := c.Controllers()
+		if err != nil {
+			return err
+		}
+		for _, c := range controllers {
+			fmt.Println(c)
 		}
 		return nil
 	},

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -168,25 +168,20 @@ func setResources(path string, resources *Resources) error {
 	return nil
 }
 
-func (c *Manager) ListControllers() ([]string, error) {
-	f, err := os.Open(filepath.Join(c.path, controllersFile))
+func (c *Manager) RootControllers() ([]string, error) {
+	b, err := ioutil.ReadFile(filepath.Join(c.unifiedMountpoint, controllersFile))
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	return strings.Fields(string(b)), nil
+}
 
-	var (
-		out []string
-		s   = bufio.NewScanner(f)
-	)
-	s.Split(bufio.ScanWords)
-	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
-		out = append(out, s.Text())
+func (c *Manager) Controllers() ([]string, error) {
+	b, err := ioutil.ReadFile(filepath.Join(c.path, controllersFile))
+	if err != nil {
+		return nil, err
 	}
-	return out, nil
+	return strings.Fields(string(b)), nil
 }
 
 type ControllerToggle int
@@ -283,7 +278,7 @@ var singleValueFiles = []string{
 }
 
 func (c *Manager) Stat() (*stats.Metrics, error) {
-	controllers, err := c.ListControllers()
+	controllers, err := c.Controllers()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix #121 