### PR TITLE
Add Mode() func to check cgroup mount type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,11 @@
 
 PACKAGES=$(shell go list ./... | grep -v /vendor/)
 
-all:
+all: cgutil
 	go build -v
+
+cgutil:
+	cd cmd/cgctl && go build -v
 
 proto:
 	protobuild --quiet ${PACKAGES}

--- a/cmd/cgctl/main.go
+++ b/cmd/cgctl/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/containerd/cgroups"
 	v2 "github.com/containerd/cgroups/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -43,6 +44,7 @@ func main() {
 		},
 	}
 	app.Commands = []cli.Command{
+		modeCommand,
 		newCommand,
 		delCommand,
 		listCommand,
@@ -156,5 +158,24 @@ var statCommand = cli.Command{
 			return err
 		}
 		return json.NewEncoder(os.Stdout).Encode(stats)
+	},
+}
+
+var modeCommand = cli.Command{
+	Name:  "mode",
+	Usage: "return the cgroup mode that is mounted on the system",
+	Action: func(clix *cli.Context) error {
+		mode := cgroups.Mode()
+		switch mode {
+		case cgroups.Legacy:
+			fmt.Println("legacy")
+		case cgroups.Hybrid:
+			fmt.Println("hybrid")
+		case cgroups.Unified:
+			fmt.Println("unified")
+		case cgroups.Unavailable:
+			fmt.Println("cgroups unavailable")
+		}
+		return nil
 	},
 }

--- a/utils.go
+++ b/utils.go
@@ -25,13 +25,59 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	units "github.com/docker/go-units"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
-var isUserNS = runningInUserNS()
+var (
+	isUserNS  = runningInUserNS()
+	checkMode sync.Once
+	cgMode    CGMode
+)
+
+const unifiedMountpoint = "/sys/fs/cgroup"
+
+// CGMode is the cgroups mode of the host system
+type CGMode int
+
+const (
+	// Unavailable cgroup mountpoint
+	Unavailable CGMode = iota
+	// Legacy cgroups v1
+	Legacy
+	// Hybrid with cgroups v1 and v2 controllers mounted
+	Hybrid
+	// Unified with only cgroups v2 mounted
+	Unified
+)
+
+// Mode returns the cgroups mode running on the host
+func Mode() CGMode {
+	checkMode.Do(func() {
+		var st unix.Statfs_t
+		if err := unix.Statfs(unifiedMountpoint, &st); err != nil {
+			cgMode = Unavailable
+			return
+		}
+		switch st.Type {
+		case unix.CGROUP2_SUPER_MAGIC:
+			cgMode = Unified
+		default:
+			cgMode = Legacy
+			if err := unix.Statfs(filepath.Join(unifiedMountpoint, "unified"), &st); err != nil {
+				return
+			}
+			if st.Type == unix.CGROUP2_SUPER_MAGIC {
+				cgMode = Hybrid
+			}
+		}
+	})
+	return cgMode
+}
 
 // runningInUserNS detects whether we are currently running in a user namespace.
 // Copied from github.com/lxc/lxd/shared/util.go


### PR DESCRIPTION
This function will return the cgroup mode that is mounted on the host system.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>