### PR TITLE
Fixed memory conversion for `reservation` from high to low.

### DIFF
--- a/v2/memory.go
+++ b/v2/memory.go
@@ -20,6 +20,7 @@ type Memory struct {
 	Swap *int64
 	Max  *int64
 	Low  *int64
+	High *int64
 }
 
 func (r *Memory) Values() (o []Value) {
@@ -39,6 +40,12 @@ func (r *Memory) Values() (o []Value) {
 		o = append(o, Value{
 			filename: "memory.low",
 			value:    *r.Low,
+		})
+	}
+	if r.High != nil {
+		o = append(o, Value{
+			filename: "memory.high",
+			value:    *r.High,
 		})
 	}
 	return o

--- a/v2/memory.go
+++ b/v2/memory.go
@@ -19,7 +19,7 @@ package v2
 type Memory struct {
 	Swap *int64
 	Max  *int64
-	High *int64
+	Low  *int64
 }
 
 func (r *Memory) Values() (o []Value) {
@@ -35,10 +35,10 @@ func (r *Memory) Values() (o []Value) {
 			value:    *r.Max,
 		})
 	}
-	if r.High != nil {
+	if r.Low != nil {
 		o = append(o, Value{
-			filename: "memory.high",
-			value:    *r.High,
+			filename: "memory.low",
+			value:    *r.Low,
 		})
 	}
 	return o

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -187,8 +187,8 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 		if l := mem.Limit; l != nil {
 			resources.Memory.Max = l
 		}
-		if h := mem.Reservation; h != nil {
-			resources.Memory.High = h
+		if l := mem.Reservation; l != nil {
+			resources.Memory.Low = l
 		}
 	}
 	if pids := spec.Pids; pids != nil {


### PR DESCRIPTION
Fix: #128 
Changed memory conversion for `reservation` from high to low. 
Signed-off-by: bpopovschi <zyqsempai@mail.ru>