### PR TITLE
Added period configuration for cpu.max

### DIFF
--- a/v2/cpu.go
+++ b/v2/cpu.go
@@ -18,7 +18,7 @@ package v2
 
 type CPU struct {
 	Weight *uint64
-	Max    *uint64
+	Max    string
 	Cpus   string
 	Mems   string
 }
@@ -30,10 +30,10 @@ func (r *CPU) Values() (o []Value) {
 			value:    *r.Weight,
 		})
 	}
-	if r.Max != nil {
+	if r.Max != "" {
 		o = append(o, Value{
 			filename: "cpu.max",
-			value:    *r.Max,
+			value:    r.Max,
 		})
 	}
 	if r.Cpus != "" {

--- a/v2/cpu.go
+++ b/v2/cpu.go
@@ -16,9 +16,24 @@
 
 package v2
 
+import (
+	"strconv"
+	"strings"
+)
+
+type CPUMax string
+
+func NewCPUMax(quota *int64, period *uint64) CPUMax {
+	max := "max"
+	if quota != nil {
+		max = strconv.FormatInt(*quota, 10)
+	}
+	return CPUMax(strings.Join([]string{max, strconv.FormatUint(*period, 10)}, " "))
+}
+
 type CPU struct {
 	Weight *uint64
-	Max    string
+	Max    CPUMax
 	Cpus   string
 	Mems   string
 }

--- a/v2/cpuv2_test.go
+++ b/v2/cpuv2_test.go
@@ -27,12 +27,16 @@ func TestCgroupv2CpuStats(t *testing.T) {
 	checkCgroupMode(t)
 	group := "/cpu-test-cg"
 	groupPath := fmt.Sprintf("%s-%d", group, os.Getpid())
-	var weight uint64 = 100
+	var (
+		quota  int64  = 10000
+		period uint64 = 8000
+		weight uint64 = 100
+	)
 	max := "10000 8000"
 	res := Resources{
 		CPU: &CPU{
 			Weight: &weight,
-			Max:    max,
+			Max:    NewCPUMax(&quota, &period),
 			Cpus:   "0",
 			Mems:   "0",
 		},

--- a/v2/cpuv2_test.go
+++ b/v2/cpuv2_test.go
@@ -28,11 +28,11 @@ func TestCgroupv2CpuStats(t *testing.T) {
 	group := "/cpu-test-cg"
 	groupPath := fmt.Sprintf("%s-%d", group, os.Getpid())
 	var weight uint64 = 100
-	var max uint64 = 8000
+	max := "10000 8000"
 	res := Resources{
 		CPU: &CPU{
 			Weight: &weight,
-			Max:    &max,
+			Max:    max,
 			Cpus:   "0",
 			Mems:   "0",
 		},
@@ -44,7 +44,7 @@ func TestCgroupv2CpuStats(t *testing.T) {
 	defer os.Remove(c.path)
 
 	checkFileContent(t, c.path, "cpu.weight", strconv.FormatUint(weight, 10))
-	checkFileContent(t, c.path, "cpu.max", strconv.FormatUint(max, 10)+" 100000")
+	checkFileContent(t, c.path, "cpu.max", max)
 	checkFileContent(t, c.path, "cpuset.cpus", "0")
 	checkFileContent(t, c.path, "cpuset.mems", "0")
 }

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -126,6 +126,8 @@ func (c *Value) write(path string, perm os.FileMode) error {
 		data = t
 	case string:
 		data = []byte(t)
+	case CPUMax:
+		data = []byte(t)
 	default:
 		return ErrInvalidFormat
 	}

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -176,7 +176,11 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 			resources.CPU.Weight = &convertedWeight
 		}
 		if period := cpu.Period; period != nil {
-			resources.CPU.Max = period
+			quota := "max"
+			if cpu.Quota != nil {
+				quota = strconv.FormatInt(*cpu.Quota, 10)
+			}
+			resources.CPU.Max = strings.Join([]string{quota, strconv.FormatUint(*period, 10)}, " ")
 		}
 	}
 	if mem := spec.Memory; mem != nil {

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -176,11 +176,7 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 			resources.CPU.Weight = &convertedWeight
 		}
 		if period := cpu.Period; period != nil {
-			quota := "max"
-			if cpu.Quota != nil {
-				quota = strconv.FormatInt(*cpu.Quota, 10)
-			}
-			resources.CPU.Max = strings.Join([]string{quota, strconv.FormatUint(*period, 10)}, " ")
+			resources.CPU.Max = NewCPUMax(cpu.Quota, period)
 		}
 	}
 	if mem := spec.Memory; mem != nil {

--- a/v2/utils_test.go
+++ b/v2/utils_test.go
@@ -58,9 +58,9 @@ func TestToResources(t *testing.T) {
 	v2resources := ToResources(&res)
 
 	assert.Equal(t, weight, *v2resources.CPU.Weight)
-	assert.Equal(t, "8000 10000", v2resources.CPU.Max)
+	assert.Equal(t, CPUMax("8000 10000"), v2resources.CPU.Max)
 
 	res2 := specs.LinuxResources{CPU: &specs.LinuxCPU{Period: &period}}
 	v2resources2 := ToResources(&res2)
-	assert.Equal(t, "max 10000", v2resources2.CPU.Max)
+	assert.Equal(t, CPUMax("max 10000"), v2resources2.CPU.Max)
 }

--- a/v2/utils_test.go
+++ b/v2/utils_test.go
@@ -48,12 +48,19 @@ func TestParseCgroupFromReader(t *testing.T) {
 }
 
 func TestToResources(t *testing.T) {
-	var quota int64 = 8000
-	var period uint64 = 10000
-	var shares uint64 = 5000
+	var (
+		quota  int64  = 8000
+		period uint64 = 10000
+		shares uint64 = 5000
+	)
 	weight := (1 + ((shares-2)*9999)/262142)
 	res := specs.LinuxResources{CPU: &specs.LinuxCPU{Quota: &quota, Period: &period, Shares: &shares}}
 	v2resources := ToResources(&res)
+
 	assert.Equal(t, weight, *v2resources.CPU.Weight)
 	assert.Equal(t, "8000 10000", v2resources.CPU.Max)
+
+	res2 := specs.LinuxResources{CPU: &specs.LinuxCPU{Period: &period}}
+	v2resources2 := ToResources(&res2)
+	assert.Equal(t, "max 10000", v2resources2.CPU.Max)
 }

--- a/v2/utils_test.go
+++ b/v2/utils_test.go
@@ -19,6 +19,9 @@ package v2
 import (
 	"strings"
 	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseCgroupFromReader(t *testing.T) {
@@ -42,4 +45,15 @@ func TestParseCgroupFromReader(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestToResources(t *testing.T) {
+	var quota int64 = 8000
+	var period uint64 = 10000
+	var shares uint64 = 5000
+	weight := (1 + ((shares-2)*9999)/262142)
+	res := specs.LinuxResources{CPU: &specs.LinuxCPU{Quota: &quota, Period: &period, Shares: &shares}}
+	v2resources := ToResources(&res)
+	assert.Equal(t, weight, *v2resources.CPU.Weight)
+	assert.Equal(t, "8000 10000", v2resources.CPU.Max)
 }


### PR DESCRIPTION
Fixes #133 

Added quota parameter to `cpu.max` resource control.
Added test for `ToResources` function.

Signed-off-by: Boris Popovschi <zyqsempai@mail.ru>