### PR TITLE
memory.events handling rework

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -526,6 +526,7 @@ func (c *Manager) freeze(path string, state State) error {
 	}
 }
 
+// MemoryEventFD returns inotify file descriptor and 'memory.events' inotify watch descriptor
 func (c *Manager) MemoryEventFD() (int, uint32, error) {
 	fpath := filepath.Join(c.path, "memory.events")
 	fd, err := syscall.InotifyInit()


### PR DESCRIPTION
Small rework of the memory.events handler in order to implement OOM handler in main containerD repo.

During the memory.events handler implementations, were made few mistakes, this PR fixes them.

Signed-off-by: Boris Popovschi <zyqsempai@mail.ru>