### PR TITLE
throttle.* metrics must be kept for non-CFQ schedulers

### DIFF
--- a/blkio.go
+++ b/blkio.go
@@ -90,54 +90,47 @@ func (b *blkioController) Update(path string, resources *specs.LinuxResources) e
 
 func (b *blkioController) Stat(path string, stats *v1.Metrics) error {
 	stats.Blkio = &v1.BlkIOStat{}
-	settings := []blkioStatSettings{
-		{
-			name:  "throttle.io_serviced",
-			entry: &stats.Blkio.IoServicedRecursive,
-		},
-		{
-			name:  "throttle.io_service_bytes",
-			entry: &stats.Blkio.IoServiceBytesRecursive,
-		},
-	}
+
+	var settings []blkioStatSettings
+
 	// Try to read CFQ stats available on all CFQ enabled kernels first
 	if _, err := os.Lstat(filepath.Join(b.Path(path), fmt.Sprintf("blkio.io_serviced_recursive"))); err == nil {
-		settings = []blkioStatSettings{}
-		settings = append(settings,
-			blkioStatSettings{
+		settings = []blkioStatSettings{
+			{
 				name:  "sectors_recursive",
 				entry: &stats.Blkio.SectorsRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "io_service_bytes_recursive",
 				entry: &stats.Blkio.IoServiceBytesRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "io_serviced_recursive",
 				entry: &stats.Blkio.IoServicedRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "io_queued_recursive",
 				entry: &stats.Blkio.IoQueuedRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "io_service_time_recursive",
 				entry: &stats.Blkio.IoServiceTimeRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "io_wait_time_recursive",
 				entry: &stats.Blkio.IoWaitTimeRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "io_merged_recursive",
 				entry: &stats.Blkio.IoMergedRecursive,
 			},
-			blkioStatSettings{
+			{
 				name:  "time_recursive",
 				entry: &stats.Blkio.IoTimeRecursive,
 			},
-		)
+		}
 	}
+
 	f, err := os.Open(filepath.Join(b.procRoot, "diskstats"))
 	if err != nil {
 		return err
@@ -149,6 +142,29 @@ func (b *blkioController) Stat(path string, stats *v1.Metrics) error {
 		return err
 	}
 
+	var size int
+	for _, t := range settings {
+		if err := b.readEntry(devices, path, t.name, t.entry); err != nil {
+			return err
+		}
+		size += len(*t.entry)
+	}
+	if size > 0 {
+		return nil
+	}
+
+	// Even the kernel is compiled with the CFQ scheduler, the cgroup may not use
+	// block devices with the CFQ scheduler. If so, we should fallback to throttle.* files.
+	settings = []blkioStatSettings{
+		{
+			name:  "throttle.io_serviced",
+			entry: &stats.Blkio.IoServicedRecursive,
+		},
+		{
+			name:  "throttle.io_service_bytes",
+			entry: &stats.Blkio.IoServiceBytesRecursive,
+		},
+	}
 	for _, t := range settings {
 		if err := b.readEntry(devices, path, t.name, t.entry); err != nil {
 			return err

--- a/blkio_test.go
+++ b/blkio_test.go
@@ -19,6 +19,8 @@ package cgroups
 import (
 	"strings"
 	"testing"
+
+	v1 "github.com/containerd/cgroups/stats/v1"
 )
 
 const data = `   7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
@@ -61,6 +63,23 @@ func TestNewBlkio(t *testing.T) {
 	}
 	if ctrl.procRoot != expectedProc {
 		t.Fatalf("expected proc FS root %q but received %q", expectedProc, ctrl.procRoot)
+	}
+}
+
+func TestBlkioStat(t *testing.T) {
+	ctrl := NewBlkio("/sys/fs/cgroup")
+
+	var metrics v1.Metrics
+	err := ctrl.Stat("", &metrics)
+	if err != nil {
+		t.Fatalf("failed to call Stat: %v", err)
+	}
+
+	if len(metrics.Blkio.IoServicedRecursive) == 0 {
+		t.Fatalf("IoServicedRecursive must not be empty")
+	}
+	if len(metrics.Blkio.IoServiceBytesRecursive) == 0 {
+		t.Fatalf("IoServiceBytesRecursive must not be empty")
 	}
 }
 

--- a/blkio_test.go
+++ b/blkio_test.go
@@ -17,6 +17,7 @@
 package cgroups
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -67,10 +68,15 @@ func TestNewBlkio(t *testing.T) {
 }
 
 func TestBlkioStat(t *testing.T) {
+	_, err := os.Stat("/sys/fs/cgroup/blkio")
+	if os.IsNotExist(err) {
+		t.Skip("failed to find /sys/fs/cgroup/blkio")
+	}
+
 	ctrl := NewBlkio("/sys/fs/cgroup")
 
 	var metrics v1.Metrics
-	err := ctrl.Stat("", &metrics)
+	err = ctrl.Stat("", &metrics)
 	if err != nil {
 		t.Fatalf("failed to call Stat: %v", err)
 	}


### PR DESCRIPTION
Since c4b9ac5, Stat() ignores
/sys/fs/cgroup/blkio/$cgroup/blkio.throttle.io_serviced and
/sys/fs/cgroup/blkio/$cgroup/blkio.throttle.io_service_bytes when
/sys/fs/cgroup/blkio/$cgroup/blkio.io_serviced_recursive is there.

However the existance of this file only indicates that the kernel is
compiled with the CFQ scheduler. There is a chance that a cgroup uses
devices with a different scheduler such as "none".

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>