### PR TITLE
bufio.Scanner.Err nits; mountinfo parser fixes

### DIFF
--- a/blkio.go
+++ b/blkio.go
@@ -181,9 +181,6 @@ func (b *blkioController) readEntry(devices map[deviceKey]string, path, name str
 	defer f.Close()
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
-		if err := sc.Err(); err != nil {
-			return err
-		}
 		// format: dev type amount
 		fields := strings.FieldsFunc(sc.Text(), splitBlkIOStatLine)
 		if len(fields) < 3 {
@@ -220,7 +217,7 @@ func (b *blkioController) readEntry(devices map[deviceKey]string, path, name str
 			Value:  v,
 		})
 	}
-	return nil
+	return sc.Err()
 }
 
 func createBlkioSettings(blkio *specs.LinuxBlockIO) []blkioSettings {

--- a/cpu.go
+++ b/cpu.go
@@ -110,9 +110,6 @@ func (c *cpuController) Stat(path string, stats *v1.Metrics) error {
 	// get or create the cpu field because cpuacct can also set values on this struct
 	sc := bufio.NewScanner(f)
 	for sc.Scan() {
-		if err := sc.Err(); err != nil {
-			return err
-		}
 		key, v, err := parseKV(sc.Text())
 		if err != nil {
 			return err
@@ -126,5 +123,5 @@ func (c *cpuController) Stat(path string, stats *v1.Metrics) error {
 			stats.CPU.Throttling.ThrottledTime = v
 		}
 	}
-	return nil
+	return sc.Err()
 }

--- a/memory.go
+++ b/memory.go
@@ -236,15 +236,15 @@ func (m *memoryController) parseStats(r io.Reader, stat *v1.MemoryStat) error {
 		line int
 	)
 	for sc.Scan() {
-		if err := sc.Err(); err != nil {
-			return err
-		}
 		key, v, err := parseKV(sc.Text())
 		if err != nil {
 			return fmt.Errorf("%d: %v", line, err)
 		}
 		raw[key] = v
 		line++
+	}
+	if err := sc.Err(); err != nil {
+		return err
 	}
 	stat.Cache = raw["cache"]
 	stat.RSS = raw["rss"]

--- a/utils.go
+++ b/utils.go
@@ -320,7 +320,14 @@ func getCgroupDestination(subsystem string) (string, error) {
 	defer f.Close()
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		fields := strings.Fields(s.Text())
+		fields := strings.Split(s.Text(), " ")
+		if len(fields) < 10 {
+			// broken mountinfo?
+			continue
+		}
+		if fields[len(fields)-3] != "cgroup" {
+			continue
+		}
 		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
 			if opt == subsystem {
 				return fields[3], nil

--- a/utils.go
+++ b/utils.go
@@ -181,6 +181,10 @@ func readPids(path string, subsystem Name) ([]Process, error) {
 			})
 		}
 	}
+	if err := s.Err(); err != nil {
+		// failed to read all pids?
+		return nil, err
+	}
 	return out, nil
 }
 
@@ -207,6 +211,9 @@ func readTasksPids(path string, subsystem Name) ([]Task, error) {
 				Path:      path,
 			})
 		}
+	}
+	if err := s.Err(); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -286,9 +293,6 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 		s       = bufio.NewScanner(r)
 	)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return nil, err
-		}
 		var (
 			text  = s.Text()
 			parts = strings.SplitN(text, ":", 3)
@@ -302,6 +306,9 @@ func parseCgroupFromReader(r io.Reader) (map[string]string, error) {
 			}
 		}
 	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
 	return cgroups, nil
 }
 
@@ -313,15 +320,15 @@ func getCgroupDestination(subsystem string) (string, error) {
 	defer f.Close()
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return "", err
-		}
 		fields := strings.Fields(s.Text())
 		for _, opt := range strings.Split(fields[len(fields)-1], ",") {
 			if opt == subsystem {
 				return fields[3], nil
 			}
 		}
+	}
+	if err := s.Err(); err != nil {
+		return "", err
 	}
 	return "", ErrNoCgroupMountDestination
 }

--- a/v1.go
+++ b/v1.go
@@ -54,9 +54,6 @@ func v1MountPoint() (string, error) {
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
-		if err := scanner.Err(); err != nil {
-			return "", err
-		}
 		var (
 			text   = scanner.Text()
 			fields = strings.Split(text, " ")
@@ -76,6 +73,9 @@ func v1MountPoint() (string, error) {
 			}
 			return filepath.Dir(fields[4]), nil
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
 	}
 	return "", ErrMountPointNotExist
 }

--- a/v1.go
+++ b/v1.go
@@ -55,22 +55,14 @@ func v1MountPoint() (string, error) {
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {
 		var (
-			text   = scanner.Text()
-			fields = strings.Split(text, " ")
-			// safe as mountinfo encodes mountpoints with spaces as \040.
-			index               = strings.Index(text, " - ")
-			postSeparatorFields = strings.Fields(text[index+3:])
-			numPostFields       = len(postSeparatorFields)
+			text      = scanner.Text()
+			fields    = strings.Split(text, " ")
+			numFields = len(fields)
 		)
-		// this is an error as we can't detect if the mount is for "cgroup"
-		if numPostFields == 0 {
-			return "", fmt.Errorf("Found no fields post '-' in %q", text)
+		if numFields < 10 {
+			return "", fmt.Errorf("mountinfo: bad entry %q", text)
 		}
-		if postSeparatorFields[0] == "cgroup" {
-			// check that the mount is properly formated.
-			if numPostFields < 3 {
-				return "", fmt.Errorf("Error found less than 3 fields post '-' in %q", text)
-			}
+		if fields[numFields-3] == "cgroup" {
 			return filepath.Dir(fields[4]), nil
 		}
 	}

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -496,16 +496,13 @@ func readKVStatsFile(path string, file string, out map[string]interface{}) error
 
 	s := bufio.NewScanner(f)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return err
-		}
 		name, value, err := parseKV(s.Text())
 		if err != nil {
 			return errors.Wrapf(err, "error while parsing %s (line=%q)", filepath.Join(path, file), s.Text())
 		}
 		out[name] = value
 	}
-	return nil
+	return s.Err()
 }
 
 func (c *Manager) Freeze() error {

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -85,6 +85,9 @@ func parseCgroupProcsFile(path string) ([]uint64, error) {
 			out = append(out, pid)
 		}
 	}
+	if err := s.Err(); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
 
@@ -144,9 +147,6 @@ func parseCgroupFromReader(r io.Reader) (string, error) {
 		s = bufio.NewScanner(r)
 	)
 	for s.Scan() {
-		if err := s.Err(); err != nil {
-			return "", err
-		}
 		var (
 			text  = s.Text()
 			parts = strings.SplitN(text, ":", 3)
@@ -158,6 +158,9 @@ func parseCgroupFromReader(r io.Reader) (string, error) {
 		if parts[0] == "0" && parts[1] == "" {
 			return parts[2], nil
 		}
+	}
+	if err := s.Err(); err != nil {
+		return "", err
 	}
 	return "", fmt.Errorf("cgroup path not found")
 }


### PR DESCRIPTION
### bufio.Scanner.Err nits

1. The call to `Err()` should be done after the `Scan()` loop,
       not inside it.
    
2. Add the call to `Err()` to after the `Scan()` loop, otherwise
       we might miss the "read only half of it" kind of error.
### mountinfo parser

####    getCgroupDestination: speedup and improve
    
1. Use `strings.Split` instead of `strings.Fields`. Split is 2x faster!
    
2. Check the number of fields and fs type before parsing options,
       this should speed things up a bit, and prevent a potential
       panic caused by invalid slice indexes.

####     v1MountPoint: simplify/speedup a bit

* Instead of relying on one split + a linear search for 
  separator + another split, let's assume the last
  three fields are the ones that are post-sepatator.