### PR TITLE
[release/1.1 backport] throttle.* metrics must be kept for non-CFQ schedulers

### DIFF
--- a/blkio_test.go
+++ b/blkio_test.go
@@ -17,6 +17,7 @@
 package cgroups
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -47,5 +48,27 @@ func TestGetDevices(t *testing.T) {
 	const expected = "/dev/sda"
 	if name != expected {
 		t.Fatalf("expected device name %q but received %q", expected, name)
+	}
+}
+
+func TestBlkioStat(t *testing.T) {
+	_, err := os.Stat("/sys/fs/cgroup/blkio")
+	if os.IsNotExist(err) {
+		t.Skip("failed to find /sys/fs/cgroup/blkio")
+	}
+
+	ctrl := NewBlkio("/sys/fs/cgroup")
+
+	var metrics Metrics
+	err = ctrl.Stat("", &metrics)
+	if err != nil {
+		t.Fatalf("failed to call Stat: %v", err)
+	}
+
+	if len(metrics.Blkio.IoServicedRecursive) == 0 {
+		t.Fatalf("IoServicedRecursive must not be empty")
+	}
+	if len(metrics.Blkio.IoServiceBytesRecursive) == 0 {
+		t.Fatalf("IoServiceBytesRecursive must not be empty")
 	}
 }


### PR DESCRIPTION
Backport fix https://github.com/containerd/cgroups/pull/147 for 1.3.4 containerd release.

Created `release/1.1` branch since we don't need cgroups v2 stuff in 1.3 releases.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>