### PR TITLE
add nil check

### DIFF
--- a/cmd/cgctl/main.go
+++ b/cmd/cgctl/main.go
@@ -77,7 +77,7 @@ var newCommand = cli.Command{
 	},
 	Action: func(clix *cli.Context) error {
 		path := clix.Args().First()
-		c, err := v2.NewManager(clix.GlobalString("mountpoint"), path, nil)
+		c, err := v2.NewManager(clix.GlobalString("mountpoint"), path, &v2.Resources{})
 		if err != nil {
 			return err
 		}

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -166,6 +166,9 @@ func writeValues(path string, values []Value) error {
 }
 
 func NewManager(mountpoint string, group string, resources *Resources) (*Manager, error) {
+	if resources == nil {
+		return nil, errors.New("resources reference is nil")
+	}
 	if err := VerifyGroupPath(group); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR addresses issue #152 

Before Output
~~~
cgroup@cgroup-VirtualBox:~/go/src/github.com/containerd/cgroups/cmd/cgctl$ sudo ./cgctl --mountpoint /sys/fs/cgroup/unified new /testb
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6e36fa]

goroutine 1 [running]:
github.com/containerd/cgroups/v2.(*Resources).EnabledControllers(...)
	/home/cgroup/go/src/github.com/containerd/cgroups/v2/manager.go:105
github.com/containerd/cgroups/v2.NewManager(0x7ffc078c1867, 0x16, 0x7ffc078c1882, 0x6, 0x0, 0x0, 0x0, 0x5)
	/home/cgroup/go/src/github.com/containerd/cgroups/v2/manager.go:186 +0x4ba
main.glob..func1(0xc00009a580, 0x0, 0xc00000e9f0)
	/home/cgroup/go/src/github.com/containerd/cgroups/cmd/cgctl/main.go:80 +0xa0
github.com/urfave/cli.HandleAction(0x79a8c0, 0x833e68, 0xc00009a580, 0xc00009a580, 0x0)
	/home/cgroup/go/pkg/mod/github.com/urfave/cli@v1.22.2/app.go:523 +0xbe
github.com/urfave/cli.Command.Run(0x817e6f, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x820e2a, 0x13, 0x0, ...)
	/home/cgroup/go/pkg/mod/github.com/urfave/cli@v1.22.2/command.go:174 +0x51c
github.com/urfave/cli.(*App).Run(0xc0000a0380, 0xc000012050, 0x5, 0x5, 0x0, 0x0)
	/home/cgroup/go/pkg/mod/github.com/urfave/cli@v1.22.2/app.go:276 +0x725
main.main()
	/home/cgroup/go/src/github.com/containerd/cgroups/cmd/cgctl/main.go:63 +0x419 
~~~

After output
~~~
cgroup@cgroup-VirtualBox:~/go/src/github.com/containerd/cgroups/cmd/cgctl$ sudo ./cgctl --mountpoint /sys/fs/cgroup/unified new /testb
[sudo] password for cgroup: 
cgroup@cgroup-VirtualBox:~/go/src/github.com/containerd/cgroups/cmd/cgctl$
~~~

A check for the resource to not be nil
Signed-off-by: Jordan Karaze <jordan.karaze@ibm.com>