### PR TITLE
cpuset: typo fix for function name

### DIFF
--- a/cpuset.go
+++ b/cpuset.go
@@ -26,7 +26,7 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func NewCputset(root string) *cpusetController {
+func NewCpuset(root string) *cpusetController {
 	return &cpusetController{
 		root: filepath.Join(root, string(Cpuset)),
 	}

--- a/utils.go
+++ b/utils.go
@@ -121,7 +121,7 @@ func defaults(root string) ([]Subsystem, error) {
 		NewNetCls(root),
 		NewNetPrio(root),
 		NewPerfEvent(root),
-		NewCputset(root),
+		NewCpuset(root),
 		NewCpu(root),
 		NewCpuacct(root),
 		NewMemory(root),


### PR DESCRIPTION
Seems like a typo in the function name - not sure if fixing will cause more good than harm, but I didn't see it being used in the containerd code base.

s/NewCputset/NewCpuset

Signed-off-by: Eric Ernst <eric@amperecomputing.com>