### PR TITLE
RFC: test: add basic creation test for systemd

### DIFF
--- a/mock_test.go
+++ b/mock_test.go
@@ -76,3 +76,11 @@ func (m *mockCgroup) delete() error {
 func (m *mockCgroup) hierarchy() ([]Subsystem, error) {
 	return m.subsystems, nil
 }
+
+func (m *mockCgroup) systemdHierarchy() ([]Subsystem, error) {
+	s, err := NewSystemd(m.root)
+	if err != nil {
+		return nil, err
+	}
+	return append([]Subsystem{s}, m.subsystems...), nil
+}


### PR DESCRIPTION
I was leveraging this package for some basic group manipulation, and all was well with cgroupfs, but I ran into some issues when trying to delete cgroups that leveraged systemd.  I copied TestCreate to add a unit test for New function that leverages systemd and ran into (different) issues (see commit message below).

Disclaimer - this could be an issue on my misunderstanding of systemd based cgroups, but in any case, adding a passing unit test for systemd would be a good idea.

**This PR adds a unit test which fails**

===

Add a create test for systemd. This currently fails, as test.slice is
not created for each subsystem.

```
=== RUN   TestCreateSystemd
    TestCreateSystemd: cgroup_test.go:80: group hugetlb was not created
--- FAIL: TestCreateSystemd (0.01s)
FAIL
exit status 1
FAIL    github.com/containerd/cgroups   0.011s
```

In non-mock testing, I noticed that deletion was failing, as the slice
still exists on the host after completing the test (and rerunning test
results in a failure). `systemctl stop test.slice` was required to
clean.

Signed-off-by: Eric Ernst <eric@amperecomputing.com>