### PR TITLE
memory: remove wrong memory.kmem.limit_in_bytes check

### DIFF
--- a/memory.go
+++ b/memory.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 
 	v1 "github.com/containerd/cgroups/stats/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -206,21 +205,6 @@ func (m *memoryController) Create(path string, resources *specs.LinuxResources) 
 	}
 	if resources.Memory == nil {
 		return nil
-	}
-	if resources.Memory.Kernel != nil {
-		// Check if kernel memory is enabled
-		// We have to limit the kernel memory here as it won't be accounted at all
-		// until a limit is set on the cgroup and limit cannot be set once the
-		// cgroup has children, or if there are already tasks in the cgroup.
-		for _, i := range []int64{1, -1} {
-			if err := retryingWriteFile(
-				filepath.Join(m.Path(path), "memory.kmem.limit_in_bytes"),
-				[]byte(strconv.FormatInt(i, 10)),
-				defaultFilePerm,
-			); err != nil {
-				return checkEBUSY(err)
-			}
-		}
 	}
 	return m.set(path, getMemorySettings(resources))
 }
@@ -431,18 +415,6 @@ func getMemorySettings(resources *specs.LinuxResources) []memorySettings {
 			value: swappiness,
 		},
 	}
-}
-
-func checkEBUSY(err error) error {
-	if pathErr, ok := err.(*os.PathError); ok {
-		if errNo, ok := pathErr.Err.(syscall.Errno); ok {
-			if errNo == unix.EBUSY {
-				return fmt.Errorf(
-					"failed to set memory.kmem.limit_in_bytes, because either tasks have already joined this cgroup or it has children")
-			}
-		}
-	}
-	return err
 }
 
 func getOomControlValue(mem *specs.LinuxMemory) *int64 {


### PR DESCRIPTION
This check is useless as:

"We have to limit the kernel memory here as it won't be accounted at all
until a limit is set on the cgroup" - if kmem accounting is enabled on
boot (no nokmem) kernel memory would be accounted without setting the
limit.

"limit cannot be set once the cgroup has children, or if there are
already tasks in the cgroup." - It can, the only restriction it should
be > usage, but setting this limit < future usage is a bad thing itself.
So there is no difference when to set this limit.

More over memory.kmem.limit_in_bytes is deprecated in mainstream linux
kernel as it was considered unreliable, see more information in:
    
commit 0158115f702b ("memcg, kmem: deprecate kmem.limit_in_bytes")
Link: https://github.com/torvalds/linux/commit/0158115f702b

Signed-off-by: Pavel Tikhomirov <ptikhomirov@virtuozzo.com>