### PR TITLE
Support updates for net_cls

### DIFF
--- a/net_cls.go
+++ b/net_cls.go
@@ -55,3 +55,7 @@ func (n *netclsController) Create(path string, resources *specs.LinuxResources) 
 	}
 	return nil
 }
+
+func (n *netclsController) Update(path string, resources *specs.LinuxResources) error {
+	return n.Create(path, resources)
+}


### PR DESCRIPTION
Allow updating the net_cls subsystem which was until now not supported. Currently trying to update the net_cls subsystem for a cgroup with the code below simply ignores the request and neither returns an error, nor updates the subsystem.

```golang
err := control.Update(&specs.LinuxResources{
	Network: &specs.LinuxNetwork{
		ClassID: &classId,
	}
})
```

