### PR TITLE
utils: export RunningInUserNS()

### DIFF
--- a/subsystem.go
+++ b/subsystem.go
@@ -59,7 +59,7 @@ func Subsystems() []Name {
 		Blkio,
 		Rdma,
 	}
-	if !isUserNS {
+	if !RunningInUserNS() {
 		n = append(n, Devices)
 	}
 	return n

--- a/utils.go
+++ b/utils.go
@@ -36,7 +36,8 @@ import (
 )
 
 var (
-	isUserNS  = runningInUserNS()
+	nsOnce    sync.Once
+	inUserNS  bool
 	checkMode sync.Once
 	cgMode    CGMode
 )
@@ -81,33 +82,37 @@ func Mode() CGMode {
 	return cgMode
 }
 
-// runningInUserNS detects whether we are currently running in a user namespace.
+// RunningInUserNS detects whether we are currently running in a user namespace.
 // Copied from github.com/lxc/lxd/shared/util.go
-func runningInUserNS() bool {
-	file, err := os.Open("/proc/self/uid_map")
-	if err != nil {
-		// This kernel-provided file only exists if user namespaces are supported
-		return false
-	}
-	defer file.Close()
+func RunningInUserNS() bool {
+	nsOnce.Do(func() {
+		file, err := os.Open("/proc/self/uid_map")
+		if err != nil {
+			// This kernel-provided file only exists if user namespaces are supported
+			return
+		}
+		defer file.Close()
 
-	buf := bufio.NewReader(file)
-	l, _, err := buf.ReadLine()
-	if err != nil {
-		return false
-	}
+		buf := bufio.NewReader(file)
+		l, _, err := buf.ReadLine()
+		if err != nil {
+			return
+		}
 
-	line := string(l)
-	var a, b, c int64
-	fmt.Sscanf(line, "%d %d %d", &a, &b, &c)
-	/*
-	 * We assume we are in the initial user namespace if we have a full
-	 * range - 4294967295 uids starting at uid 0.
-	 */
-	if a == 0 && b == 0 && c == 4294967295 {
-		return false
-	}
-	return true
+		line := string(l)
+		var a, b, c int64
+		fmt.Sscanf(line, "%d %d %d", &a, &b, &c)
+
+		/*
+		 * We assume we are in the initial user namespace if we have a full
+		 * range - 4294967295 uids starting at uid 0.
+		 */
+		if a == 0 && b == 0 && c == 4294967295 {
+			return
+		}
+		inUserNS = true
+	})
+	return inUserNS
 }
 
 // defaults returns all known groups
@@ -132,7 +137,7 @@ func defaults(root string) ([]Subsystem, error) {
 	}
 	// only add the devices cgroup if we are not in a user namespace
 	// because modifications are not allowed
-	if !isUserNS {
+	if !RunningInUserNS() {
 		s = append(s, NewDevices(root))
 	}
 	// add the hugetlb cgroup if error wasn't due to missing hugetlb


### PR DESCRIPTION
Exporting this utility, so that consumers of the containerd/cgroups package can use this, without having to duplicate this functionality, for example; https://github.com/containerd/containerd/blob/0088c2de8019dfd38040634931ce05e04b1aa74f/sys/userns_linux.go#L31-L62

The only difference (currently) is that containerd/cgroups does not have a "stub" for this function for non-Linux (whereas containerd/sys does); not sure if it would make sense to add a stub here (given that this repository is assuming Linux)