### PR TITLE
gha: replace uses of deprecated "set-env", "add-path"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       #
       # Checkout repos
@@ -95,8 +95,8 @@ jobs:
       - name: Set env
         shell: bash
         run: |
-          echo "::set-env name=GOPATH::${{ github.workspace }}"
-          echo "::add-path::${{ github.workspace }}/bin"
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
 
       - name: Checkout cgroups
         uses: actions/checkout@v2


### PR DESCRIPTION
see https://github.com/containerd/cgroups/pull/184#issuecomment-730340021

These have been deprecated (related to CVE-2020-15228):
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

This fixes CI failing;

    Error: Unable to process command '::set-env name=GOPATH::/home/runner/work/cgroups/cgroups' successfully.
    Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
    Error: Unable to process command '::add-path::/home/runner/work/cgroups/cgroups/bin' successfully.
    Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
