### PR TITLE
Only append Hugetlb in Subsystems list when available

### DIFF
--- a/subsystem.go
+++ b/subsystem.go
@@ -18,6 +18,7 @@ package cgroups
 
 import (
 	"fmt"
+	"os"
 
 	v1 "github.com/containerd/cgroups/stats/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -46,7 +47,6 @@ const (
 // available on most linux systems
 func Subsystems() []Name {
 	n := []Name{
-		Hugetlb,
 		Freezer,
 		Pids,
 		NetCLS,
@@ -61,6 +61,9 @@ func Subsystems() []Name {
 	}
 	if !RunningInUserNS() {
 		n = append(n, Devices)
+	}
+	if _, err := os.Stat("/sys/kernel/mm/hugepages"); err == nil {
+		n = append(n, Hugetlb)
 	}
 	return n
 }


### PR DESCRIPTION
This is to fix failed tests when system doesn't have hugetlb.

In test, the `Subsystems()` function is used,

https://github.com/containerd/cgroups/blob/4cbc285b33272039927a0b066d3412799db8de14/cgroup_test.go#L47-L52

However the `mockCgroup` creates the subsystems from `defaults`, which only adds hugetls when available,

https://github.com/containerd/cgroups/blob/4cbc285b33272039927a0b066d3412799db8de14/mock_test.go#L29-L41

https://github.com/containerd/cgroups/blob/4cbc285b33272039927a0b066d3412799db8de14/utils.go#L143-L146

 