### PR TITLE
Fix wrong existingPath translate in docker.

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -71,9 +71,6 @@ func existingPath(paths map[string]string, suffix string) Path {
 		if err != nil {
 			return errorPath(err)
 		}
-		if rel == "." {
-			rel = dest
-		}
 		paths[n] = filepath.Join("/", rel)
 	}
 	return func(name Name) (string, error) {


### PR DESCRIPTION
Description

I try to run the code in docker environment.
```
	path, _ := cgroups.PidPath(os.Getpid())(cgroups.Memory)
	fmt.Println(path)
```
It will get a path `/docker/cb4effaee355365a5b5f163f98c38fdadb41487cb655d0b4b39fd7a032a6bb75`
But in the container, there is no directory `/sys/fs/cgroup/memory/docker/cb4effaee355365a5b5f163f98c38fdadb41487cb655d0b4b39fd7a032a6bb75`.(In fact, the path is exists in the host machine.)
When I try to use the path to Load cgroup in docker, it will throw error.  

I think use `/sys/fs/cgroup/memory/` is right.

If i misunderstand the usage of the package, please tell me...

