### PR TITLE
v2: ebpf: replace deprecated prog.Attach/prog.Detach and fix closer

### DIFF
--- a/v2/ebpf.go
+++ b/v2/ebpf.go
@@ -19,6 +19,7 @@ package v2
 import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/asm"
+	"github.com/cilium/ebpf/link"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -42,12 +43,23 @@ func LoadAttachCgroupDeviceFilter(insts asm.Instructions, license string, dirFD 
 	if err != nil {
 		return nilCloser, err
 	}
-	if err := prog.Attach(dirFD, ebpf.AttachCGroupDevice, unix.BPF_F_ALLOW_MULTI); err != nil {
+	err = link.RawAttachProgram(link.RawAttachProgramOptions{
+		Target:  dirFD,
+		Program: prog,
+		Attach:  ebpf.AttachCGroupDevice,
+		Flags:   unix.BPF_F_ALLOW_MULTI,
+	})
+	if err != nil {
 		return nilCloser, errors.Wrap(err, "failed to call BPF_PROG_ATTACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI)")
 	}
 	closer := func() error {
-		if err := prog.Detach(dirFD, ebpf.AttachCGroupDevice, unix.BPF_F_ALLOW_MULTI); err != nil {
-			return errors.Wrap(err, "failed to call BPF_PROG_DETACH (BPF_CGROUP_DEVICE, BPF_F_ALLOW_MULTI)")
+		err = link.RawDetachProgram(link.RawDetachProgramOptions{
+			Target:  dirFD,
+			Program: prog,
+			Attach:  ebpf.AttachCGroupDevice,
+		})
+		if err != nil {
+			return errors.Wrap(err, "failed to call BPF_PROG_DETACH (BPF_CGROUP_DEVICE)")
 		}
 		return nil
 	}


### PR DESCRIPTION
similar to https://github.com/opencontainers/runc/pull/2903

this was added in https://github.com/containerd/cgroups/commit/33207b488aea7b6d1ce3bc9a3768b1c5386ea801 (https://github.com/containerd/cgroups/pull/116), but had the same issue as the code in runc.

Caught by golangci-lint when enabling golint:

    v2/ebpf.go:45:12: SA1019: prog.Attach is deprecated: use link.RawAttachProgram instead. (staticcheck)
        if err := prog.Attach(dirFD, ebpf.AttachCGroupDevice, unix.BPF_F_ALLOW_MULTI); err != nil {
                  ^
    v2/ebpf.go:49:13: SA1019: prog.Detach is deprecated: use link.RawDetachProgram instead. (staticcheck)
        if err := prog.Detach(dirFD, ebpf.AttachCGroupDevice, unix.BPF_F_ALLOW_MULTI); err != nil {
                  ^

worth noting that we currently call prog.Detach() with unix.BPF_F_ALLOW_MULTI;
https://github.com/golang/sys/blob/22da62e12c0cd9c1da93581e1113ca4d82a5be14/unix/zerrors_linux.go#L178

    BPF_F_ALLOW_MULTI = 0x2

Looking at the source code for prog.Detach(); https://github.com/cilium/ebpf/blob/v0.4.0/prog.go#L579-L581,
this would _always_ produce an error:

    if flags != 0 {
        return errors.New("flags must be zero")
    }

Note that the flags parameter is not used (except for that validation)

Signed-off-by: Sebastiaan van Stijn <github@gone.nl>