### PR TITLE
Use /proc/partitions to get device names

### DIFF
--- a/blkio.go
+++ b/blkio.go
@@ -130,7 +130,7 @@ func (b *blkioController) Stat(path string, stats *v1.Metrics) error {
 		}
 	}
 
-	f, err := os.Open(filepath.Join(b.procRoot, "diskstats"))
+	f, err := os.Open(filepath.Join(b.procRoot, "partitions"))
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,10 @@ func getDevices(r io.Reader) (map[deviceKey]string, error) {
 		s       = bufio.NewScanner(r)
 		devices = make(map[deviceKey]string)
 	)
-	for s.Scan() {
+	for i := 0; s.Scan(); i++ {
+		if i < 2 {
+			continue
+		}
 		fields := strings.Fields(s.Text())
 		major, err := strconv.Atoi(fields[0])
 		if err != nil {
@@ -352,7 +355,7 @@ func getDevices(r io.Reader) (map[deviceKey]string, error) {
 		if _, ok := devices[key]; ok {
 			continue
 		}
-		devices[key] = filepath.Join("/dev", fields[2])
+		devices[key] = filepath.Join("/dev", fields[3])
 	}
 	return devices, s.Err()
 }

--- a/blkio_test.go
+++ b/blkio_test.go
@@ -24,18 +24,19 @@ import (
 	v1 "github.com/containerd/cgroups/stats/v1"
 )
 
-const data = `   7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
-   7       1 loop1 0 0 0 0 0 0 0 0 0 0 0
-   7       2 loop2 0 0 0 0 0 0 0 0 0 0 0
-   7       3 loop3 0 0 0 0 0 0 0 0 0 0 0
-   7       4 loop4 0 0 0 0 0 0 0 0 0 0 0
-   7       5 loop5 0 0 0 0 0 0 0 0 0 0 0
-   7       6 loop6 0 0 0 0 0 0 0 0 0 0 0
-   7       7 loop7 0 0 0 0 0 0 0 0 0 0 0
-   8       0 sda 1892042 187697 63489222 1246284 1389086 2887005 134903104 11390608 1 1068060 12692228
-   8       1 sda1 1762875 37086 61241570 1200512 1270037 2444415 131214808 11152764 1 882624 12409308
-   8       2 sda2 2 0 4 0 0 0 0 0 0 0 0
-   8       5 sda5 129102 150611 2244440 45716 18447 442590 3688296 67268 0 62584 112984`
+const data = `major minor  #blocks  name
+
+   7        0          4 loop0
+   7        1     163456 loop1
+   7        2     149616 loop2
+   7        3     147684 loop3
+   7        4     122572 loop4
+   7        5       8936 loop5
+   7        6      31464 loop6
+   7        7     182432 loop7
+ 259        0  937692504 nvme0n1
+ 259        1      31744 nvme0n1p1
+`
 
 func TestGetDevices(t *testing.T) {
 	r := strings.NewReader(data)
@@ -43,13 +44,18 @@ func TestGetDevices(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	name, ok := devices[deviceKey{8, 0}]
-	if !ok {
-		t.Fatal("no device found for 8,0")
-	}
-	const expected = "/dev/sda"
-	if name != expected {
-		t.Fatalf("expected device name %q but received %q", expected, name)
+	for dev, expected := range map[deviceKey]string{
+		deviceKey{7, 0}: "/dev/loop0",
+		deviceKey{259, 0}: "/dev/nvme0n1",
+		deviceKey{259, 1}: "/dev/nvme0n1p1",
+	} {
+		name, ok := devices[dev]
+		if !ok {
+			t.Fatalf("no device found for %d:%d", dev.major, dev.minor)
+		}
+		if name != expected {
+			t.Fatalf("expected device name %q but received %q", expected, name)
+		}
 	}
 }
 


### PR DESCRIPTION
On systems with hundreds of disks/CPUs [/proc/partitions](https://elixir.bootlin.com/linux/v5.12.1/source/block/genhd.c#L935) is way less expensive than [/proc/diskstats](https://elixir.bootlin.com/linux/v5.12.1/source/block/genhd.c#L1265).

Here is a `perf top` example from a system that has hundreds of `loop` mounts:
<img width="1435" alt="Screen Shot 2021-05-04 at 8 36 25 PM" src="https://user-images.githubusercontent.com/169976/117095278-c8875780-ad1a-11eb-902b-8f65f9feed84.png">

Since the code is only using major/minor numbers and drive name we should probably use a way more light-weight `/proc/partitions` endpoint

Signed-off-by: Alexey Ivanov <rbtz@dropbox.com>