### PR TITLE
utils: export ParseCgroupFile()

### DIFF
--- a/paths.go
+++ b/paths.go
@@ -39,7 +39,7 @@ func StaticPath(path string) Path {
 // NestedPath will nest the cgroups based on the calling processes cgroup
 // placing its child processes inside its own path
 func NestedPath(suffix string) Path {
-	paths, err := parseCgroupFile("/proc/self/cgroup")
+	paths, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		return errorPath(err)
 	}
@@ -50,7 +50,7 @@ func NestedPath(suffix string) Path {
 // This is commonly used for the Load function to restore an existing container
 func PidPath(pid int) Path {
 	p := fmt.Sprintf("/proc/%d/cgroup", pid)
-	paths, err := parseCgroupFile(p)
+	paths, err := ParseCgroupFile(p)
 	if err != nil {
 		return errorPath(errors.Wrapf(err, "parse cgroup file %s", p))
 	}

--- a/paths_test.go
+++ b/paths_test.go
@@ -41,7 +41,7 @@ func TestSelfPath(t *testing.T) {
 	} else if err != nil {
 		t.Fatal(err)
 	}
-	paths, err := parseCgroupFile("/proc/self/cgroup")
+	paths, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestPidPath(t *testing.T) {
 	} else if err != nil {
 		t.Fatal(err)
 	}
-	paths, err := parseCgroupFile("/proc/self/cgroup")
+	paths, err := ParseCgroupFile("/proc/self/cgroup")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils.go
+++ b/utils.go
@@ -285,7 +285,16 @@ func parseKV(raw string) (string, uint64, error) {
 	}
 }
 
-func parseCgroupFile(path string) (map[string]string, error) {
+// ParseCgroupFile parses the given cgroup file, typically /proc/self/cgroup
+// or /proc/<pid>/cgroup, into a map of subsystems to cgroup paths, e.g.
+//   "cpu": "/user.slice/user-1000.slice"
+//   "pids": "/user.slice/user-1000.slice"
+// etc.
+//
+// Note that for cgroup v2 unified hierarchy, there are no per-controller
+// cgroup paths, so the resulting map will have a single element where the key
+// is empty string ("") and the value is the cgroup path the <pid> is in.
+func ParseCgroupFile(path string) (map[string]string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
this exports the ParseCgroupFile() function, so that external consumers (such as moby) can use this function, instead of the implementation in runc's libcontainer (which is not intended for external consumers).

The GoDoc documentation was borrowed from runc  https://github.com/opencontainers/runc/commit/d244b4058ee81ca43182bffe536d63ec70326904 (added @kolyshkin as co-author)


Relates to https://github.com/moby/moby/pull/42071 (https://github.com/moby/moby/pull/42071/files#r585767248)
Relates to https://github.com/moby/moby/issues/42452
