### PR TITLE
cgroup v1: implement AddProc()

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -162,6 +162,16 @@ func (c *cgroup) Add(process Process) error {
 	return c.add(process)
 }
 
+// AddProc moves the provided process id into the new cgroup
+func (c *cgroup) AddProc(pid uint64) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.err != nil {
+		return c.err
+	}
+	return c.Add(Process{Pid: int(pid)})
+}
+
 func (c *cgroup) add(process Process) error {
 	for _, s := range pathers(c.subsystems) {
 		p, err := c.path(s.Name())

--- a/control.go
+++ b/control.go
@@ -61,6 +61,8 @@ type Cgroup interface {
 	New(string, *specs.LinuxResources) (Cgroup, error)
 	// Add adds a process to the cgroup (cgroup.procs)
 	Add(Process) error
+	// AddProc adds the process with the given id to the cgroup (cgroup.procs)
+	AddProc(pid uint64) error
 	// AddTask adds a process to the cgroup (tasks)
 	AddTask(Process) error
 	// Delete removes the cgroup as a whole


### PR DESCRIPTION
This implements AddProc() for cgroups v1 to make the API a closer match with the cgroupsv2 API.
