### PR TITLE
v2: remove unimplemented errors and ErrorHandler, IgnoreNotExist

### DIFF
--- a/v2/errors.go
+++ b/v2/errors.go
@@ -22,16 +22,8 @@ import (
 )
 
 var (
-	ErrInvalidPid               = errors.New("cgroups: pid must be greater than 0")
-	ErrMountPointNotExist       = errors.New("cgroups: cgroup mountpoint does not exist")
-	ErrInvalidFormat            = errors.New("cgroups: parsing file with invalid format failed")
-	ErrFreezerNotSupported      = errors.New("cgroups: freezer cgroup (v2) not supported on this system")
-	ErrMemoryNotSupported       = errors.New("cgroups: memory cgroup (v2) not supported on this system")
-	ErrPidsNotSupported         = errors.New("cgroups: pids cgroup (v2) not supported on this system")
-	ErrCPUNotSupported          = errors.New("cgroups: cpu cgroup (v2) not supported on this system")
-	ErrCgroupDeleted            = errors.New("cgroups: cgroup deleted")
-	ErrNoCgroupMountDestination = errors.New("cgroups: cannot find cgroup mount destination")
-	ErrInvalidGroupPath         = errors.New("cgroups: invalid group path")
+	ErrInvalidFormat    = errors.New("cgroups: parsing file with invalid format failed")
+	ErrInvalidGroupPath = errors.New("cgroups: invalid group path")
 )
 
 // ErrorHandler is a function that handles and acts on errors

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -18,21 +18,9 @@ package v2
 
 import (
 	"errors"
-	"os"
 )
 
 var (
 	ErrInvalidFormat    = errors.New("cgroups: parsing file with invalid format failed")
 	ErrInvalidGroupPath = errors.New("cgroups: invalid group path")
 )
-
-// ErrorHandler is a function that handles and acts on errors
-type ErrorHandler func(err error) error
-
-// IgnoreNotExist ignores any errors that are for not existing files
-func IgnoreNotExist(err error) error {
-	if os.IsNotExist(err) {
-		return nil
-	}
-	return err
-}


### PR DESCRIPTION
relates to https://github.com/containerd/containerd/pull/5739

### v2: remove errors that are never returned

Unlike v1, the v2 package never returns these errors. This patch removes
them to prevent consumers of this package from assuming they may be returned,
and writing special handling around them.

> **NOTE: this is a breaking change, so (following SemVer) would require a major
> version update**. However, consumers should not use these errors. Alternatively,
> we could "deprecate" them first. Making it a breaking change makes it more
> visible (compile time error), which may help consumers to find incorrect
> handling of these errors.



### v2: remove ErrorHandler and IgnoreNotExist as they are not implemented

Unlike v1, these are not used/implemented in the v2 code, so removing
these.
