### PR TITLE
Improvements on cgroup v2 support

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -272,6 +272,8 @@ func (c *Manager) ToggleControllers(controllers []string, t ControllerToggle) er
 			// controller is already written.
 			// So we only return the last error.
 			lastErr = errors.Wrapf(err, "failed to write subtree controllers %+v to %q", controllers, filePath)
+		} else {
+			lastErr = nil
 		}
 	}
 	return lastErr

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -301,15 +301,23 @@ func (c *Manager) NewChild(name string, resources *Resources) (*Manager, error) 
 	if err := os.MkdirAll(path, defaultDirPerm); err != nil {
 		return nil, err
 	}
+	m := Manager{
+		unifiedMountpoint: c.unifiedMountpoint,
+		path:              path,
+	}
+	if resources != nil {
+		if err := m.ToggleControllers(resources.EnabledControllers(), Enable); err != nil {
+			// clean up cgroup dir on failure
+			os.Remove(path)
+			return nil, err
+		}
+	}
 	if err := setResources(path, resources); err != nil {
 		// clean up cgroup dir on failure
 		os.Remove(path)
 		return nil, err
 	}
-	return &Manager{
-		unifiedMountpoint: c.unifiedMountpoint,
-		path:              path,
-	}, nil
+	return &m, nil
 }
 
 func (c *Manager) AddProc(pid uint64) error {


### PR DESCRIPTION
Hi, this pr contains two improvements on cgroupv2 support.

* When creating a child cgroup using `manager.NewChild()`, resources limits are set before the corresponding controllers are enabled. The patch fixes this issue following the way how it is dealt in `NewManager()`
* When toggling controller settings in `manager.ToggleControllers()`, the settings are written recursively from root controller to `m`'s parent. As long as its parent is successfully written with the given settings, all possible errors happens before can safely ignored.