### PR TITLE
cgroup.go: avoid panic on nil interface

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -327,6 +327,9 @@ func (c *cgroup) processes(subsystem Name, recursive bool, pType procType) ([]Pr
 	if err != nil {
 		return nil, err
 	}
+	if s == nil {
+		return nil, fmt.Errorf("cgroups: %s doesn't exist in %s subsystem", sp, subsystem)
+	}
 	path := s.(pather).Path(sp)
 	var processes []Process
 	err = filepath.Walk(path, func(p string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Hi, this PR's related issue is #205, which is a potential nil interface panic case. 

In https://github.com/containerd/cgroups/blob/main/cgroup.go#L330, if we pass a subsystem that doesn't exist into func (c *cgroup) Processes(subsystem Name, recursive bool), we would get a panic: interface conversion: interface is nil, not cgroups.pather.

So we'd check nil interface and return error if it's nil to avoid panic.