### PR TITLE
Fix potential dirfd leak.

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -658,7 +658,7 @@ func setDevices(path string, devices []specs.LinuxDeviceCgroup) error {
 	if err != nil {
 		return err
 	}
-	dirFD, err := unix.Open(path, unix.O_DIRECTORY|unix.O_RDONLY, 0600)
+	dirFD, err := unix.Open(path, unix.O_DIRECTORY|unix.O_RDONLY|unix.O_CLOEXEC, 0600)
 	if err != nil {
 		return fmt.Errorf("cannot get dir FD for %s", path)
 	}


### PR DESCRIPTION
Make sure we don't accidentally leak this dir fd by using O_CLOEXEC.