### PR TITLE
Fix panic in NewSystemd on nil values

### DIFF
--- a/v2/cpuv2_test.go
+++ b/v2/cpuv2_test.go
@@ -68,6 +68,25 @@ func TestSystemdCgroupCpuController(t *testing.T) {
 	checkFileContent(t, c.path, "cpu.weight", strconv.FormatUint(weight, 10))
 }
 
+func TestSystemdCgroupCpuController_NilWeight(t *testing.T) {
+	checkCgroupMode(t)
+	group := "testingCpuNilWeight.slice"
+	// nil weight defaults to 100
+	var quota int64 = 10000
+	var period uint64 = 8000
+	cpuMax := NewCPUMax(&quota, &period)
+	res := Resources{
+		CPU: &CPU{
+			Weight: nil,
+			Max:    cpuMax,
+		},
+	}
+	_, err := NewSystemd("/", group, -1, &res)
+	if err != nil {
+		t.Fatal("failed to init new cgroup systemd manager: ", err)
+	}
+}
+
 func TestExtractQuotaAndPeriod(t *testing.T) {
 	var (
 		period uint64

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -734,12 +734,12 @@ func NewSystemd(slice, group string, pid int, resources *Resources) (*Manager, e
 		properties = append(properties, newSystemdProperty("PIDs", []uint32{uint32(pid)}))
 	}
 
-	if resources.Memory != nil && *resources.Memory.Max != 0 {
+	if resources.Memory != nil && resources.Memory.Max != nil && *resources.Memory.Max != 0 {
 		properties = append(properties,
 			newSystemdProperty("MemoryMax", uint64(*resources.Memory.Max)))
 	}
 
-	if resources.CPU != nil && *resources.CPU.Weight != 0 {
+	if resources.CPU != nil && resources.CPU.Weight != nil && *resources.CPU.Weight != 0 {
 		properties = append(properties,
 			newSystemdProperty("CPUWeight", *resources.CPU.Weight))
 	}


### PR DESCRIPTION
NewSystemd previously panicked if it was given a nil resource value for
resources.Memory.Max or resources.CPU.Weight (if resources.CPU or
resources.Memory is non-nil)

This also checks the value of Max and Weight before dereferencing them.

Previous to this change, the unit tests I added would fail like this:

cpu:
```
# go test ./v2/...
--- FAIL: TestSystemdCgroupCpuController_NilWeight (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6dde61]

goroutine 36 [running]:
testing.tRunner.func1.2({0x7250e0, 0xa12af0})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x7250e0, 0xa12af0})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/containerd/cgroups/v2.NewSystemd({0x7e4144, 0x1}, {0x7809c5, 0x19}, 0xffffffffffffffff, 0xc00014ff10)
	/home/ec2-user/cgroups/v2/manager.go:742 +0xdc1
github.com/containerd/cgroups/v2.TestSystemdCgroupCpuController_NilWeight(0xc000210340)
	/home/ec2-user/cgroups/v2/cpuv2_test.go:84 +0x125
testing.tRunner(0xc000210340, 0x7960d0)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
FAIL	github.com/containerd/cgroups/v2	0.043s
?   	github.com/containerd/cgroups/v2/stats	[no test files]
FAIL
```
