### PR TITLE
Update Go version and fedora base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.x'
+          go-version: '1.17.x'
 
       - name: Set env
         shell: bash
@@ -90,7 +90,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.x'
+          go-version: '1.17.x'
 
       - name: Set env
         shell: bash

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,19 +3,19 @@
 
 Vagrant.configure("2") do |config|
 # Fedora box is used for testing cgroup v2 support
-  config.vm.box = "fedora/32-cloud-base"
+  config.vm.box = "fedora/35-cloud-base"
   config.vm.provider :virtualbox do |v|
-    v.memory = 2048
+    v.memory = 4096
     v.cpus = 2
   end
   config.vm.provider :libvirt do |v|
-    v.memory = 2048
+    v.memory = 4096
     v.cpus = 2
   end
   config.vm.provision "shell", inline: <<-SHELL
     set -eux -o pipefail
     # configuration
-    GO_VERSION="1.15"
+    GO_VERSION="1.17.7"
 
     # install gcc and Golang
     dnf -y install gcc


### PR DESCRIPTION
Update Fedora to 35 in Vagrantfile (matches containerd core project), memory size to match as well, and start testing in Vagrant and GH Actions with Go 1.17.

Signed-off-by: Phil Estes <estesp@amazon.com>