### PR TITLE
Do not override devices in cgv2 because of default settings by runc

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -241,6 +241,10 @@ func (c *Manager) Controllers() ([]string, error) {
 }
 
 func (c *Manager) Update(resources *Resources) error {
+	// skip updating devices because the default devices setting is by runc.
+	if len(resources.Devices) > 0 {
+		resources.Devices = []specs.LinuxDeviceCgroup{}
+	}
 	return setResources(c.path, resources)
 }
 


### PR DESCRIPTION
Update of devices in cgroup v2 will override runc settings. This is not an addition, but a complete overwrite. Therefore, it will overwrite the default settings. I'd like to fix this if I will have the time but once I tried to disable it. Let me know what the community thinks.

https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#default-devices
https://github.com/opencontainers/runc/blob/2436322fef995f60194554c5ce2947df2e18661d/libcontainer/specconv/spec_linux.go#L188