### PR TITLE
Check that cgroup is empty before deleting

### DIFF
--- a/cgroup.go
+++ b/cgroup.go
@@ -229,7 +229,7 @@ func (c *cgroup) Delete() error {
 	var errs []string
 	for _, s := range c.subsystems {
 		// kernel prevents cgroups with running process from being removed, check the tree is empty
-		procs, err := c.Processes(s.Name(), true)
+		procs, err := c.processes(s.Name(), true, cgroupProcs)
 		if err != nil {
 			return err
 		}

--- a/cgroup.go
+++ b/cgroup.go
@@ -234,7 +234,7 @@ func (c *cgroup) Delete() error {
 			return err
 		}
 		if len(procs) > 0 {
-			errs = append(errs, string(s.Name()))
+			errs = append(errs, fmt.Sprintf("%s (contains running processes)", string(s.Name())))
 			continue
 		}
 		if d, ok := s.(deleter); ok {

--- a/cgroup.go
+++ b/cgroup.go
@@ -84,7 +84,7 @@ func Load(hierarchy Hierarchy, path Path, opts ...InitOpts) (Cgroup, error) {
 	for _, s := range pathers(subsystems) {
 		p, err := path(s.Name())
 		if err != nil {
-			if  errors.Is(err, os.ErrNotExist) {
+			if errors.Is(err, os.ErrNotExist) {
 				return nil, ErrCgroupDeleted
 			}
 			if err == ErrControllerNotActive {
@@ -228,6 +228,15 @@ func (c *cgroup) Delete() error {
 	}
 	var errs []string
 	for _, s := range c.subsystems {
+		// kernel prevents cgroups with running process from being removed, check the tree is empty
+		procs, err := c.Processes(s.Name(), true)
+		if err != nil {
+			return err
+		}
+		if len(procs) > 0 {
+			errs = append(errs, string(s.Name()))
+			continue
+		}
 		if d, ok := s.(deleter); ok {
 			sp, err := c.path(s.Name())
 			if err != nil {
@@ -247,6 +256,7 @@ func (c *cgroup) Delete() error {
 			if err := remove(path); err != nil {
 				errs = append(errs, path)
 			}
+			continue
 		}
 	}
 	if len(errs) > 0 {

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -337,6 +337,14 @@ func (c *Manager) AddProc(pid uint64) error {
 }
 
 func (c *Manager) Delete() error {
+	// kernel prevents cgroups with running process from being removed, check the tree is empty
+	processes, err := c.Procs(true)
+	if err != nil {
+		return err
+	}
+	if len(processes) > 0 {
+		return fmt.Errorf("cgroups: unable to remove path %q: still contains running processes", c.path)
+	}
 	return remove(c.path)
 }
 


### PR DESCRIPTION
The kernel will block an attempt to rmdir a cgroup path that still has running processes in it. Since the removal code uses the standard `os.RemoveAll` function, the Go runtime will helpfully fall back to an `rm -rf`-like removal algorithm if the cheap `unlink`/`rmdir` attempts fail.

Since cgroup files cannot be removed, the caller ends up with an unhelpful "unlinkat /sys/fs/cgroup/.../cgroup.events: operation not permitted" error message that doesn't actually give any actionable information because the original error was swallowed by the runtime.

This changes the `Delete` functions to detect cgroups with still running processes and return an error indicating that removal cannot be done.

Signed-off-by: Josh Seba <sebajosh@outlook.com>