### PR TITLE
Add PropSlice(slice) when slice has suffix .scope

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -768,12 +768,12 @@ func NewSystemd(slice, group string, pid int, resources *Resources) (*Manager, e
 		newSystemdProperty("IOAccounting", true),
 	}
 
-	// if we create a slice, the parent is defined via a Wants=
 	if strings.HasSuffix(group, ".slice") {
+		// if we create a slice, the parent is defined via a Wants=
 		properties = append(properties, systemdDbus.PropWants(defaultSlice))
 	} else {
-		// otherwise, we use Slice=
-		properties = append(properties, systemdDbus.PropSlice(defaultSlice))
+		// Otherwise it's a scope, which we put into a Slice=
+		properties = append(properties, systemdDbus.PropSlice(slice))
 	}
 
 	// only add pid if its valid, -1 is used w/ general slice creation.


### PR DESCRIPTION
In NewSystemd, if the slice ends with .scope, we put into a Slice=PropSlice(slice).

refer to: https://github.com/opencontainers/runc/blob/main/libcontainer/cgroups/systemd/v2.go#L262

Fixes: #238

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>