### PR TITLE
Support cgroup.AddThread in cgroupv2 manager

### DIFF
--- a/v2/manager.go
+++ b/v2/manager.go
@@ -336,6 +336,14 @@ func (c *Manager) AddProc(pid uint64) error {
 	return writeValues(c.path, []Value{v})
 }
 
+func (c *Manager) AddThread(tid uint64) error {
+	v := Value{
+		filename: cgroupThreads,
+		value:    tid,
+	}
+	return writeValues(c.path, []Value{v})
+}
+
 func (c *Manager) Delete() error {
 	return remove(c.path)
 }

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	cgroupProcs    = "cgroup.procs"
+	cgroupThreads  = "cgroup.threads"
 	defaultDirPerm = 0755
 )
 


### PR DESCRIPTION
In threaded mode, we need to add thread id to cgroup.threads. This work is to make the cgroupv2 manager support AddThread().

Fixes: #242

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>