### PR TITLE
Don't use ioutil

### DIFF
--- a/cgroup_test.go
+++ b/cgroup_test.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -30,7 +29,7 @@ import (
 // using t.Error in test were defers do cleanup on the filesystem
 
 func TestCreate(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +56,7 @@ func TestCreate(t *testing.T) {
 }
 
 func TestStat(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func TestStat(t *testing.T) {
 }
 
 func TestAdd(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +101,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestAddFilteredSubsystems(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +158,7 @@ func TestAddFilteredSubsystems(t *testing.T) {
 }
 
 func TestAddTask(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +181,7 @@ func TestAddTask(t *testing.T) {
 }
 
 func TestAddTaskFilteredSubsystems(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +223,7 @@ func TestAddTaskFilteredSubsystems(t *testing.T) {
 }
 
 func TestListPids(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +258,7 @@ func TestListPids(t *testing.T) {
 }
 
 func TestListTasksPids(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +293,7 @@ func TestListTasksPids(t *testing.T) {
 }
 
 func readValue(mock *mockCgroup, path string) (string, error) {
-	data, err := ioutil.ReadFile(filepath.Join(mock.root, path))
+	data, err := os.ReadFile(filepath.Join(mock.root, path))
 	if err != nil {
 		return "", err
 	}
@@ -346,7 +345,7 @@ func mockNewNotInRdma(subsystems []Subsystem, path Path, resources *specs.LinuxR
 }
 
 func TestLoad(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +366,7 @@ func TestLoad(t *testing.T) {
 }
 
 func TestLoadWithMissingSubsystems(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +400,7 @@ func TestLoadWithMissingSubsystems(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,7 +416,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestCreateSubCgroup(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,7 +454,7 @@ func TestCreateSubCgroup(t *testing.T) {
 }
 
 func TestFreezeThaw(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -484,7 +483,7 @@ func TestFreezeThaw(t *testing.T) {
 }
 
 func TestSubsystems(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -507,7 +506,7 @@ func TestSubsystems(t *testing.T) {
 
 func TestCpusetParent(t *testing.T) {
 	const expected = "0-3"
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cpuacct.go
+++ b/cpuacct.go
@@ -19,7 +19,6 @@ package cgroups
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -72,7 +71,7 @@ func (c *cpuacctController) Stat(path string, stats *v1.Metrics) error {
 
 func (c *cpuacctController) percpuUsage(path string) ([]uint64, error) {
 	var usage []uint64
-	data, err := ioutil.ReadFile(filepath.Join(c.Path(path), "cpuacct.usage_percpu"))
+	data, err := os.ReadFile(filepath.Join(c.Path(path), "cpuacct.usage_percpu"))
 	if err != nil {
 		return nil, err
 	}

--- a/cpuacct_test.go
+++ b/cpuacct_test.go
@@ -17,7 +17,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,7 +28,7 @@ sched_delay 3
 `
 
 func TestGetUsage(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +42,7 @@ func TestGetUsage(t *testing.T) {
 		t.Fatal(err)
 	}
 	current := filepath.Join(mock.root, string(Cpuacct), "test", "cpuacct.stat")
-	if err = ioutil.WriteFile(
+	if err = os.WriteFile(
 		current,
 		[]byte(cpuacctStatData),
 		defaultFilePerm,

--- a/cpuset.go
+++ b/cpuset.go
@@ -19,7 +19,6 @@ package cgroups
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -87,10 +86,10 @@ func (c *cpusetController) Update(path string, resources *specs.LinuxResources) 
 }
 
 func (c *cpusetController) getValues(path string) (cpus []byte, mems []byte, err error) {
-	if cpus, err = ioutil.ReadFile(filepath.Join(path, "cpuset.cpus")); err != nil && !os.IsNotExist(err) {
+	if cpus, err = os.ReadFile(filepath.Join(path, "cpuset.cpus")); err != nil && !os.IsNotExist(err) {
 		return
 	}
-	if mems, err = ioutil.ReadFile(filepath.Join(path, "cpuset.mems")); err != nil && !os.IsNotExist(err) {
+	if mems, err = os.ReadFile(filepath.Join(path, "cpuset.mems")); err != nil && !os.IsNotExist(err) {
 		return
 	}
 	return cpus, mems, nil

--- a/freezer.go
+++ b/freezer.go
@@ -17,7 +17,7 @@
 package cgroups
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -58,7 +58,7 @@ func (f *freezerController) changeState(path string, state State) error {
 }
 
 func (f *freezerController) state(path string) (State, error) {
-	current, err := ioutil.ReadFile(filepath.Join(f.root, path, "freezer.state"))
+	current, err := os.ReadFile(filepath.Join(f.root, path, "freezer.state"))
 	if err != nil {
 		return "", err
 	}

--- a/memory_test.go
+++ b/memory_test.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -259,18 +258,15 @@ func checkMemoryStatHasNoSwap(t *testing.T, mem *v1.MemoryStat) {
 
 // buildMemoryMetrics creates fake cgroups memory entries in a temporary dir. Returns the fake cgroups root
 func buildMemoryMetrics(t *testing.T, modules []string, metrics []string) string {
-	tmpRoot, err := ioutil.TempDir("", "memtests")
-	if err != nil {
-		t.Fatal(err)
-	}
+	tmpRoot := t.TempDir()
 	tmpDir := path.Join(tmpRoot, string(Memory))
 	if err := os.MkdirAll(tmpDir, defaultDirPerm); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(tmpDir, "memory.stat"), []byte(memoryData), defaultFilePerm); err != nil {
+	if err := os.WriteFile(path.Join(tmpDir, "memory.stat"), []byte(memoryData), defaultFilePerm); err != nil {
 		t.Fatal(err)
 	}
-	if err := ioutil.WriteFile(path.Join(tmpDir, "memory.oom_control"), []byte(memoryOomControlData), defaultFilePerm); err != nil {
+	if err := os.WriteFile(path.Join(tmpDir, "memory.oom_control"), []byte(memoryOomControlData), defaultFilePerm); err != nil {
 		t.Fatal(err)
 	}
 	cnt := 0
@@ -282,7 +278,7 @@ func buildMemoryMetrics(t *testing.T, modules []string, metrics []string) string
 			} else {
 				fileName = path.Join(tmpDir, strings.Join([]string{"memory", mod, metric}, "."))
 			}
-			if err := ioutil.WriteFile(fileName, []byte(fmt.Sprintln(cnt)), defaultFilePerm); err != nil {
+			if err := os.WriteFile(fileName, []byte(fmt.Sprintln(cnt)), defaultFilePerm); err != nil {
 				t.Fatal(err)
 			}
 			cnt++

--- a/mock_test.go
+++ b/mock_test.go
@@ -17,20 +17,17 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 )
 
 func init() {
 	defaultFilePerm = 0666
 }
 
-func newMock() (*mockCgroup, error) {
-	root, err := ioutil.TempDir("", "cgroups")
-	if err != nil {
-		return nil, err
-	}
+func newMock(tb testing.TB) (*mockCgroup, error) {
+	root := tb.TempDir()
 	subsystems, err := defaults(root)
 	if err != nil {
 		return nil, err
@@ -54,7 +51,7 @@ func newMock() (*mockCgroup, error) {
 			value: []byte("0-3"),
 		},
 	} {
-		if err := ioutil.WriteFile(filepath.Join(root, "cpuset", v.name), v.value, defaultFilePerm); err != nil {
+		if err := os.WriteFile(filepath.Join(root, "cpuset", v.name), v.value, defaultFilePerm); err != nil {
 			return nil, err
 		}
 	}

--- a/pids.go
+++ b/pids.go
@@ -17,7 +17,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -69,7 +68,7 @@ func (p *pidsController) Stat(path string, stats *v1.Metrics) error {
 		return err
 	}
 	var max uint64
-	maxData, err := ioutil.ReadFile(filepath.Join(p.Path(path), "pids.max"))
+	maxData, err := os.ReadFile(filepath.Join(p.Path(path), "pids.max"))
 	if err != nil {
 		return err
 	}

--- a/pids_test.go
+++ b/pids_test.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -29,7 +28,7 @@ import (
 )
 
 func TestPids(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +45,7 @@ func TestPids(t *testing.T) {
 		t.Fatal(err)
 	}
 	current := filepath.Join(mock.root, "pids", "test", "pids.current")
-	if err = ioutil.WriteFile(
+	if err = os.WriteFile(
 		current,
 		[]byte(strconv.Itoa(5)),
 		defaultFilePerm,
@@ -86,7 +85,7 @@ func TestPids(t *testing.T) {
 }
 
 func TestPidsMissingCurrent(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +102,7 @@ func TestPidsMissingCurrent(t *testing.T) {
 }
 
 func TestPidsMissingMax(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -117,7 +116,7 @@ func TestPidsMissingMax(t *testing.T) {
 		t.Fatal(err)
 	}
 	current := filepath.Join(mock.root, "pids", "test", "pids.current")
-	if err = ioutil.WriteFile(
+	if err = os.WriteFile(
 		current,
 		[]byte(strconv.Itoa(5)),
 		defaultFilePerm,
@@ -132,7 +131,7 @@ func TestPidsMissingMax(t *testing.T) {
 }
 
 func TestPidsOverflowMax(t *testing.T) {
-	mock, err := newMock()
+	mock, err := newMock(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -146,7 +145,7 @@ func TestPidsOverflowMax(t *testing.T) {
 		t.Fatal(err)
 	}
 	current := filepath.Join(mock.root, "pids", "test", "pids.current")
-	if err = ioutil.WriteFile(
+	if err = os.WriteFile(
 		current,
 		[]byte(strconv.Itoa(5)),
 		defaultFilePerm,
@@ -158,7 +157,7 @@ func TestPidsOverflowMax(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err = ioutil.WriteFile(
+	if err = os.WriteFile(
 		max,
 		bytes,
 		defaultFilePerm,

--- a/rdma.go
+++ b/rdma.go
@@ -17,7 +17,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -126,13 +125,13 @@ func toRdmaEntry(strEntries []string) []*v1.RdmaEntry {
 
 func (p *rdmaController) Stat(path string, stats *v1.Metrics) error {
 
-	currentData, err := ioutil.ReadFile(filepath.Join(p.Path(path), "rdma.current"))
+	currentData, err := os.ReadFile(filepath.Join(p.Path(path), "rdma.current"))
 	if err != nil {
 		return err
 	}
 	currentPerDevices := strings.Split(string(currentData), "\n")
 
-	maxData, err := ioutil.ReadFile(filepath.Join(p.Path(path), "rdma.max"))
+	maxData, err := os.ReadFile(filepath.Join(p.Path(path), "rdma.max"))
 	if err != nil {
 		return err
 	}

--- a/utils.go
+++ b/utils.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -200,7 +199,7 @@ func hugePageSizes() ([]string, error) {
 		pageSizes []string
 		sizeList  = []string{"B", "KB", "MB", "GB", "TB", "PB"}
 	)
-	files, err := ioutil.ReadDir("/sys/kernel/mm/hugepages")
+	files, err := os.ReadDir("/sys/kernel/mm/hugepages")
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +215,7 @@ func hugePageSizes() ([]string, error) {
 }
 
 func readUint(path string) (uint64, error) {
-	v, err := ioutil.ReadFile(path)
+	v, err := os.ReadFile(path)
 	if err != nil {
 		return 0, err
 	}
@@ -382,7 +381,7 @@ func retryingWriteFile(path string, data []byte, mode os.FileMode) error {
 	// Retry writes on EINTR; see:
 	//    https://github.com/golang/go/issues/38033
 	for {
-		err := ioutil.WriteFile(path, data, mode)
+		err := os.WriteFile(path, data, mode)
 		if err == nil {
 			return nil
 		} else if !errors.Is(err, syscall.EINTR) {

--- a/v2/manager.go
+++ b/v2/manager.go
@@ -21,7 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -147,7 +147,7 @@ func (c *Value) write(path string, perm os.FileMode) error {
 	// Retry writes on EINTR; see:
 	//    https://github.com/golang/go/issues/38033
 	for {
-		err := ioutil.WriteFile(
+		err := os.WriteFile(
 			filepath.Join(path, c.filename),
 			data,
 			perm,
@@ -225,7 +225,7 @@ func setResources(path string, resources *Resources) error {
 }
 
 func (c *Manager) RootControllers() ([]string, error) {
-	b, err := ioutil.ReadFile(filepath.Join(c.unifiedMountpoint, controllersFile))
+	b, err := os.ReadFile(filepath.Join(c.unifiedMountpoint, controllersFile))
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (c *Manager) RootControllers() ([]string, error) {
 }
 
 func (c *Manager) Controllers() ([]string, error) {
-	b, err := ioutil.ReadFile(filepath.Join(c.path, controllersFile))
+	b, err := os.ReadFile(filepath.Join(c.path, controllersFile))
 	if err != nil {
 		return nil, err
 	}
@@ -530,7 +530,7 @@ func readSingleFile(path string, file string, out map[string]interface{}) error 
 		return err
 	}
 	defer f.Close()
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}

--- a/v2/state.go
+++ b/v2/state.go
@@ -17,7 +17,7 @@
 package v2
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -50,7 +50,7 @@ func (s State) Values() []Value {
 }
 
 func fetchState(path string) (State, error) {
-	current, err := ioutil.ReadFile(filepath.Join(path, cgroupFreeze))
+	current, err := os.ReadFile(filepath.Join(path, cgroupFreeze))
 	if err != nil {
 		return Unknown, err
 	}

--- a/v2/testutils_test.go
+++ b/v2/testutils_test.go
@@ -17,7 +17,7 @@
 package v2
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -39,14 +39,14 @@ func checkCgroupMode(t *testing.T) {
 }
 
 func checkCgroupControllerSupported(t *testing.T, controller string) {
-	b, err := ioutil.ReadFile(filepath.Join(defaultCgroup2Path, controllersFile))
+	b, err := os.ReadFile(filepath.Join(defaultCgroup2Path, controllersFile))
 	if err != nil || !strings.Contains(string(b), controller) {
 		t.Skipf("Controller: %s is not supported on that system", controller)
 	}
 }
 
 func checkFileContent(t *testing.T, path, filename, value string) {
-	out, err := ioutil.ReadFile(filepath.Join(path, filename))
+	out, err := os.ReadFile(filepath.Join(path, filename))
 	if err != nil {
 		t.Fatalf("failed to read %s file", filename)
 	}

--- a/v2/utils.go
+++ b/v2/utils.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -243,7 +242,7 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 
 // Gets uint64 parsed content of single value cgroup stat file
 func getStatFileContentUint64(filePath string) uint64 {
-	contents, err := ioutil.ReadFile(filePath)
+	contents, err := os.ReadFile(filePath)
 	if err != nil {
 		return 0
 	}
@@ -265,7 +264,7 @@ func readIoStats(path string) []*stats.IOEntry {
 	// more details on the io.stat file format: https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 	var usage []*stats.IOEntry
 	fpath := filepath.Join(path, "io.stat")
-	currentData, err := ioutil.ReadFile(fpath)
+	currentData, err := os.ReadFile(fpath)
 	if err != nil {
 		return usage
 	}
@@ -319,7 +318,7 @@ func readIoStats(path string) []*stats.IOEntry {
 }
 
 func rdmaStats(filepath string) []*stats.RdmaEntry {
-	currentData, err := ioutil.ReadFile(filepath)
+	currentData, err := os.ReadFile(filepath)
 	if err != nil {
 		return []*stats.RdmaEntry{}
 	}
@@ -407,7 +406,7 @@ func readHugeTlbStats(path string) []*stats.HugeTlbStat {
 				hugeTlb = &stats.HugeTlbStat{}
 			}
 			hugeTlb.Pagesize = pageSize
-			out, err := ioutil.ReadFile(filepath.Join(path, file.Name()))
+			out, err := os.ReadFile(filepath.Join(path, file.Name()))
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
io/ioutil has been deprecated since Go 1.16.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>