### PR TITLE
Upgrade Go compiler to 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.x'
+          go-version: '1.19.x'
 
       - name: Set env
         shell: bash
@@ -94,7 +94,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.x'
+          go-version: '1.19.x'
 
       - name: Set env
         shell: bash


### PR DESCRIPTION
Upgrades the Go compiler in GHA to Go 1.19

Signed-off-by: Austin Vazquez <macedonv@amazon.com>