### PR TITLE
Swap 'retryingWriteFile' for os.WriteFile

### DIFF
--- a/blkio.go
+++ b/blkio.go
@@ -71,7 +71,7 @@ func (b *blkioController) Create(path string, resources *specs.LinuxResources) e
 	}
 	for _, t := range createBlkioSettings(resources.BlockIO) {
 		if t.value != nil {
-			if err := retryingWriteFile(
+			if err := os.WriteFile(
 				filepath.Join(b.Path(path), "blkio."+t.name),
 				t.format(t.value),
 				defaultFilePerm,

--- a/cgroup.go
+++ b/cgroup.go
@@ -207,7 +207,7 @@ func (c *cgroup) add(process Process, pType procType, subsystems ...Name) error 
 		if err != nil {
 			return err
 		}
-		err = retryingWriteFile(
+		err = os.WriteFile(
 			filepath.Join(s.Path(p), pType),
 			[]byte(strconv.Itoa(process.Pid)),
 			defaultFilePerm,

--- a/cpu.go
+++ b/cpu.go
@@ -82,7 +82,7 @@ func (c *cpuController) Create(path string, resources *specs.LinuxResources) err
 				value = []byte(strconv.FormatInt(*t.ivalue, 10))
 			}
 			if value != nil {
-				if err := retryingWriteFile(
+				if err := os.WriteFile(
 					filepath.Join(c.Path(path), "cpu."+t.name),
 					value,
 					defaultFilePerm,

--- a/cpuset.go
+++ b/cpuset.go
@@ -68,7 +68,7 @@ func (c *cpusetController) Create(path string, resources *specs.LinuxResources) 
 			},
 		} {
 			if t.value != "" {
-				if err := retryingWriteFile(
+				if err := os.WriteFile(
 					filepath.Join(c.Path(path), "cpuset."+t.name),
 					[]byte(t.value),
 					defaultFilePerm,
@@ -133,7 +133,7 @@ func (c *cpusetController) copyIfNeeded(current, parent string) error {
 		return err
 	}
 	if isEmpty(currentCpus) {
-		if err := retryingWriteFile(
+		if err := os.WriteFile(
 			filepath.Join(current, "cpuset.cpus"),
 			parentCpus,
 			defaultFilePerm,
@@ -142,7 +142,7 @@ func (c *cpusetController) copyIfNeeded(current, parent string) error {
 		}
 	}
 	if isEmpty(currentMems) {
-		if err := retryingWriteFile(
+		if err := os.WriteFile(
 			filepath.Join(current, "cpuset.mems"),
 			parentMems,
 			defaultFilePerm,

--- a/devices.go
+++ b/devices.go
@@ -60,7 +60,7 @@ func (d *devicesController) Create(path string, resources *specs.LinuxResources)
 		if device.Type == "" {
 			device.Type = "a"
 		}
-		if err := retryingWriteFile(
+		if err := os.WriteFile(
 			filepath.Join(d.Path(path), file),
 			[]byte(deviceString(device)),
 			defaultFilePerm,

--- a/freezer.go
+++ b/freezer.go
@@ -50,7 +50,7 @@ func (f *freezerController) Thaw(path string) error {
 }
 
 func (f *freezerController) changeState(path string, state State) error {
-	return retryingWriteFile(
+	return os.WriteFile(
 		filepath.Join(f.root, path, "freezer.state"),
 		[]byte(strings.ToUpper(string(state))),
 		defaultFilePerm,

--- a/hugetlb.go
+++ b/hugetlb.go
@@ -56,7 +56,7 @@ func (h *hugetlbController) Create(path string, resources *specs.LinuxResources)
 		return err
 	}
 	for _, limit := range resources.HugepageLimits {
-		if err := retryingWriteFile(
+		if err := os.WriteFile(
 			filepath.Join(h.Path(path), strings.Join([]string{"hugetlb", limit.Pagesize, "limit_in_bytes"}, ".")),
 			[]byte(strconv.FormatUint(limit.Limit, 10)),
 			defaultFilePerm,

--- a/memory.go
+++ b/memory.go
@@ -104,22 +104,22 @@ func (m *memoryPressureEvent) EventFile() string {
 type MemoryPressureLevel string
 
 // The three memory pressure levels are as follows.
-//  - The "low" level means that the system is reclaiming memory for new
-//    allocations. Monitoring this reclaiming activity might be useful for
-//    maintaining cache level. Upon notification, the program (typically
-//    "Activity Manager") might analyze vmstat and act in advance (i.e.
-//    prematurely shutdown unimportant services).
-//  - The "medium" level means that the system is experiencing medium memory
-//    pressure, the system might be making swap, paging out active file caches,
-//    etc. Upon this event applications may decide to further analyze
-//    vmstat/zoneinfo/memcg or internal memory usage statistics and free any
-//    resources that can be easily reconstructed or re-read from a disk.
-//  - The "critical" level means that the system is actively thrashing, it is
-//    about to out of memory (OOM) or even the in-kernel OOM killer is on its
-//    way to trigger. Applications should do whatever they can to help the
-//    system. It might be too late to consult with vmstat or any other
-//    statistics, so it is advisable to take an immediate action.
-//    "https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt" Section 11
+//   - The "low" level means that the system is reclaiming memory for new
+//     allocations. Monitoring this reclaiming activity might be useful for
+//     maintaining cache level. Upon notification, the program (typically
+//     "Activity Manager") might analyze vmstat and act in advance (i.e.
+//     prematurely shutdown unimportant services).
+//   - The "medium" level means that the system is experiencing medium memory
+//     pressure, the system might be making swap, paging out active file caches,
+//     etc. Upon this event applications may decide to further analyze
+//     vmstat/zoneinfo/memcg or internal memory usage statistics and free any
+//     resources that can be easily reconstructed or re-read from a disk.
+//   - The "critical" level means that the system is actively thrashing, it is
+//     about to out of memory (OOM) or even the in-kernel OOM killer is on its
+//     way to trigger. Applications should do whatever they can to help the
+//     system. It might be too late to consult with vmstat or any other
+//     statistics, so it is advisable to take an immediate action.
+//     "https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt" Section 11
 const (
 	LowPressure      MemoryPressureLevel = "low"
 	MediumPressure   MemoryPressureLevel = "medium"
@@ -131,21 +131,21 @@ const (
 type EventNotificationMode string
 
 // There are three optional modes that specify different propagation behavior:
-//  - "default": this is the default behavior specified above. This mode is the
-//    same as omitting the optional mode parameter, preserved by backwards
-//    compatibility.
-//  - "hierarchy": events always propagate up to the root, similar to the default
-//    behavior, except that propagation continues regardless of whether there are
-//    event listeners at each level, with the "hierarchy" mode. In the above
-//    example, groups A, B, and C will receive notification of memory pressure.
-//  - "local": events are pass-through, i.e. they only receive notifications when
-//    memory pressure is experienced in the memcg for which the notification is
-//    registered. In the above example, group C will receive notification if
-//    registered for "local" notification and the group experiences memory
-//    pressure. However, group B will never receive notification, regardless if
-//    there is an event listener for group C or not, if group B is registered for
-//    local notification.
-//    "https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt" Section 11
+//   - "default": this is the default behavior specified above. This mode is the
+//     same as omitting the optional mode parameter, preserved by backwards
+//     compatibility.
+//   - "hierarchy": events always propagate up to the root, similar to the default
+//     behavior, except that propagation continues regardless of whether there are
+//     event listeners at each level, with the "hierarchy" mode. In the above
+//     example, groups A, B, and C will receive notification of memory pressure.
+//   - "local": events are pass-through, i.e. they only receive notifications when
+//     memory pressure is experienced in the memcg for which the notification is
+//     registered. In the above example, group C will receive notification if
+//     registered for "local" notification and the group experiences memory
+//     pressure. However, group B will never receive notification, regardless if
+//     there is an event listener for group C or not, if group B is registered for
+//     local notification.
+//     "https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt" Section 11
 const (
 	DefaultMode   EventNotificationMode = "default"
 	LocalMode     EventNotificationMode = "local"
@@ -394,7 +394,7 @@ func (m *memoryController) parseOomControlStats(r io.Reader, stat *v1.MemoryOomC
 func (m *memoryController) set(path string, settings []memorySettings) error {
 	for _, t := range settings {
 		if t.value != nil {
-			if err := retryingWriteFile(
+			if err := os.WriteFile(
 				filepath.Join(m.Path(path), "memory."+t.name),
 				[]byte(strconv.FormatInt(*t.value, 10)),
 				defaultFilePerm,
@@ -472,7 +472,7 @@ func (m *memoryController) memoryEvent(path string, event MemoryEvent) (uintptr,
 	defer evtFile.Close()
 	data := fmt.Sprintf("%d %d %s", efd, evtFile.Fd(), event.Arg())
 	evctlPath := filepath.Join(root, "cgroup.event_control")
-	if err := retryingWriteFile(evctlPath, []byte(data), 0700); err != nil {
+	if err := os.WriteFile(evctlPath, []byte(data), 0700); err != nil {
 		unix.Close(efd)
 		return 0, err
 	}

--- a/net_cls.go
+++ b/net_cls.go
@@ -47,7 +47,7 @@ func (n *netclsController) Create(path string, resources *specs.LinuxResources) 
 		return err
 	}
 	if resources.Network != nil && resources.Network.ClassID != nil && *resources.Network.ClassID > 0 {
-		return retryingWriteFile(
+		return os.WriteFile(
 			filepath.Join(n.Path(path), "net_cls.classid"),
 			[]byte(strconv.FormatUint(uint64(*resources.Network.ClassID), 10)),
 			defaultFilePerm,

--- a/net_prio.go
+++ b/net_prio.go
@@ -48,7 +48,7 @@ func (n *netprioController) Create(path string, resources *specs.LinuxResources)
 	}
 	if resources.Network != nil {
 		for _, prio := range resources.Network.Priorities {
-			if err := retryingWriteFile(
+			if err := os.WriteFile(
 				filepath.Join(n.Path(path), "net_prio.ifpriomap"),
 				formatPrio(prio.Name, prio.Priority),
 				defaultFilePerm,

--- a/pids.go
+++ b/pids.go
@@ -49,7 +49,7 @@ func (p *pidsController) Create(path string, resources *specs.LinuxResources) er
 		return err
 	}
 	if resources.Pids != nil && resources.Pids.Limit > 0 {
-		return retryingWriteFile(
+		return os.WriteFile(
 			filepath.Join(p.Path(path), "pids.max"),
 			[]byte(strconv.FormatInt(resources.Pids.Limit, 10)),
 			defaultFilePerm,

--- a/rdma.go
+++ b/rdma.go
@@ -67,7 +67,7 @@ func (p *rdmaController) Create(path string, resources *specs.LinuxResources) er
 	for device, limit := range resources.Rdma {
 		if device != "" && (limit.HcaHandles != nil || limit.HcaObjects != nil) {
 			limit := limit
-			return retryingWriteFile(
+			return os.WriteFile(
 				filepath.Join(p.Path(path), "rdma.max"),
 				[]byte(createCmdString(device, &limit)),
 				defaultFilePerm,

--- a/utils.go
+++ b/utils.go
@@ -18,7 +18,6 @@ package cgroups
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	units "github.com/docker/go-units"
@@ -256,8 +254,10 @@ func parseKV(raw string) (string, uint64, error) {
 
 // ParseCgroupFile parses the given cgroup file, typically /proc/self/cgroup
 // or /proc/<pid>/cgroup, into a map of subsystems to cgroup paths, e.g.
-//   "cpu": "/user.slice/user-1000.slice"
-//   "pids": "/user.slice/user-1000.slice"
+//
+//	"cpu": "/user.slice/user-1000.slice"
+//	"pids": "/user.slice/user-1000.slice"
+//
 // etc.
 //
 // The resulting map does not have an element for cgroup v2 unified hierarchy.
@@ -375,17 +375,4 @@ func cleanPath(path string) string {
 		path, _ = filepath.Rel(string(os.PathSeparator), filepath.Clean(string(os.PathSeparator)+path))
 	}
 	return path
-}
-
-func retryingWriteFile(path string, data []byte, mode os.FileMode) error {
-	// Retry writes on EINTR; see:
-	//    https://github.com/golang/go/issues/38033
-	for {
-		err := os.WriteFile(path, data, mode)
-		if err == nil {
-			return nil
-		} else if !errors.Is(err, syscall.EINTR) {
-			return err
-		}
-	}
 }


### PR DESCRIPTION
retryingWriteFile was a simple wrapper around os.WriteFile to retry writes on EINTR. This was added due to change in the go runtime causing more EINTRs to occur, more here:
https://github.com/golang/go/issues/38033

However since 1.15 the stdlib automatically retries IO on EINTR, and since this package uses things from go 1.16, all consumers of this pkg should be on > 1.15 making the wrapper redundant.