### PR TITLE
Rename the package to github.com/containerd/cgroups/v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ so the resulting slice would be located here on disk:
 
 ```go
 import (
-    "github.com/containerd/cgroups/v2/cgroup2"
+    "github.com/containerd/cgroups/v3/cgroup2"
     specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/blkio.go
+++ b/cgroup1/blkio.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )

--- a/cgroup1/blkio_test.go
+++ b/cgroup1/blkio_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 )
 
 const data = `major minor  #blocks  name

--- a/cgroup1/cgroup.go
+++ b/cgroup1/cgroup.go
@@ -28,7 +28,7 @@ import (
 	"syscall"
 	"time"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
 )

--- a/cgroup1/control.go
+++ b/cgroup1/control.go
@@ -19,7 +19,7 @@ package cgroup1
 import (
 	"os"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/cpu.go
+++ b/cgroup1/cpu.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/cpuacct.go
+++ b/cgroup1/cpuacct.go
@@ -24,7 +24,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 )
 
 const nanosecondsInSecond = 1000000000

--- a/cgroup1/hugetlb.go
+++ b/cgroup1/hugetlb.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/memory.go
+++ b/cgroup1/memory.go
@@ -25,7 +25,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"golang.org/x/sys/unix"
 )

--- a/cgroup1/memory_test.go
+++ b/cgroup1/memory_test.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"testing"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 )
 
 const memoryData = `cache 1

--- a/cgroup1/pids.go
+++ b/cgroup1/pids.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/pids_test.go
+++ b/cgroup1/pids_test.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"testing"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/rdma.go
+++ b/cgroup1/rdma.go
@@ -23,7 +23,7 @@ import (
 	"strconv"
 	"strings"
 
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/subsystem.go
+++ b/cgroup1/subsystem.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/containerd/cgroups/v2"
-	v1 "github.com/containerd/cgroups/v2/cgroup1/stats"
+	"github.com/containerd/cgroups/v3"
+	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 

--- a/cgroup1/utils.go
+++ b/cgroup1/utils.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/cgroups/v2"
+	"github.com/containerd/cgroups/v3"
 	units "github.com/docker/go-units"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )

--- a/cgroup2/manager.go
+++ b/cgroup2/manager.go
@@ -30,7 +30,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/cgroups/v2/cgroup2/stats"
+	"github.com/containerd/cgroups/v3/cgroup2/stats"
 
 	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"

--- a/cgroup2/utils.go
+++ b/cgroup2/utils.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/containerd/cgroups/v2/cgroup2/stats"
+	"github.com/containerd/cgroups/v3/cgroup2/stats"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"

--- a/cmd/cgctl/main.go
+++ b/cmd/cgctl/main.go
@@ -22,8 +22,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/containerd/cgroups/v2"
-	"github.com/containerd/cgroups/v2/cgroup2"
+	"github.com/containerd/cgroups/v3"
+	"github.com/containerd/cgroups/v3/cgroup2"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 )

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -2,10 +2,10 @@ module github.com/containerd/cgroups/cmd
 
 go 1.16
 
-replace github.com/containerd/cgroups/v2 => ../
+replace github.com/containerd/cgroups/v3 => ../
 
 require (
-	github.com/containerd/cgroups/v2 v2.0.0-00010101000000-000000000000
+	github.com/containerd/cgroups/v3 v3.0.0-00010101000000-000000000000
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli v1.22.5
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/containerd/cgroups/v2
+module github.com/containerd/cgroups/v3
 
 go 1.17
 


### PR DESCRIPTION
containerd/cgroups 1.0.x is having v2 directory which makes importing github.com/containerd/cgroups/v2 ambiguous.

So the gogo-less version will be v3 and we will skip v2.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>