### PR TITLE
Make cgroup1.Load and cgroup2.Load closer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ uses the v1 implementation of cgroups.
 
 ```go
 shares := uint64(100)
-control, err := cgroup1.New(cgroup1.Default, cgroup1.StaticPath("/test"), &specs.LinuxResources{
+control, err := cgroup1.New(cgroup1.StaticPath("/test"), &specs.LinuxResources{
     CPU: &specs.LinuxCPU{
         Shares: &shares,
     },

--- a/cgroup1/cgroup.go
+++ b/cgroup1/cgroup.go
@@ -34,14 +34,14 @@ import (
 )
 
 // New returns a new control via the cgroup cgroups interface
-func New(hierarchy Hierarchy, path Path, resources *specs.LinuxResources, opts ...InitOpts) (Cgroup, error) {
+func New(path Path, resources *specs.LinuxResources, opts ...InitOpts) (Cgroup, error) {
 	config := newInitConfig()
 	for _, o := range opts {
 		if err := o(config); err != nil {
 			return nil, err
 		}
 	}
-	subsystems, err := hierarchy()
+	subsystems, err := config.hiearchy()
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +71,7 @@ func New(hierarchy Hierarchy, path Path, resources *specs.LinuxResources, opts .
 
 // Load will load an existing cgroup and allow it to be controlled
 // All static path should not include `/sys/fs/cgroup/` prefix, it should start with your own cgroups name
-func Load(hierarchy Hierarchy, path Path, opts ...InitOpts) (Cgroup, error) {
+func Load(path Path, opts ...InitOpts) (Cgroup, error) {
 	config := newInitConfig()
 	for _, o := range opts {
 		if err := o(config); err != nil {
@@ -79,7 +79,7 @@ func Load(hierarchy Hierarchy, path Path, opts ...InitOpts) (Cgroup, error) {
 		}
 	}
 	var activeSubsystems []Subsystem
-	subsystems, err := hierarchy()
+	subsystems, err := config.hiearchy()
 	if err != nil {
 		return nil, err
 	}

--- a/cgroup1/cgroup_test.go
+++ b/cgroup1/cgroup_test.go
@@ -34,7 +34,7 @@ func TestCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -61,7 +61,7 @@ func TestStat(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -83,7 +83,7 @@ func TestAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -106,7 +106,7 @@ func TestAddFilteredSubsystems(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -163,7 +163,7 @@ func TestAddTask(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -186,7 +186,7 @@ func TestAddTaskFilteredSubsystems(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -228,7 +228,7 @@ func TestListPids(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -263,7 +263,7 @@ func TestListTasksPids(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -350,12 +350,12 @@ func TestLoad(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if control, err = Load(mock.hierarchy, StaticPath("test")); err != nil {
+	if control, err = Load(StaticPath("test"), WithHiearchy(mock.hierarchy)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -385,7 +385,7 @@ func TestLoadWithMissingSubsystems(t *testing.T) {
 		t.Error("control is nil")
 		return
 	}
-	if control, err = Load(mock.hierarchy, StaticPath("test")); err != nil {
+	if control, err = Load(StaticPath("test"), WithHiearchy(mock.hierarchy)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -405,7 +405,7 @@ func TestDelete(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -421,7 +421,7 @@ func TestCreateSubCgroup(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -459,7 +459,7 @@ func TestFreezeThaw(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -488,7 +488,7 @@ func TestSubsystems(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("test"), &specs.LinuxResources{})
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -511,7 +511,7 @@ func TestCpusetParent(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer mock.delete()
-	control, err := New(mock.hierarchy, StaticPath("/parent/child"), &specs.LinuxResources{})
+	control, err := New(StaticPath("/parent/child"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return

--- a/cgroup1/opts.go
+++ b/cgroup1/opts.go
@@ -36,11 +36,13 @@ type InitOpts func(*InitConfig) error
 type InitConfig struct {
 	// InitCheck can be used to check initialization errors from the subsystem
 	InitCheck InitCheck
+	hiearchy  Hierarchy
 }
 
 func newInitConfig() *InitConfig {
 	return &InitConfig{
 		InitCheck: RequireDevices,
+		hiearchy:  Default,
 	}
 }
 
@@ -58,4 +60,13 @@ func RequireDevices(s Subsystem, _ Path, _ error) error {
 		return ErrDevicesRequired
 	}
 	return ErrIgnoreSubsystem
+}
+
+// WithHiearchy sets a list of cgroup subsystems.
+// The default list is coming from /proc/self/mountinfo.
+func WithHiearchy(h Hierarchy) InitOpts {
+	return func(c *InitConfig) error {
+		c.hiearchy = h
+		return nil
+	}
 }

--- a/cmd/cgctl/main.go
+++ b/cmd/cgctl/main.go
@@ -99,7 +99,7 @@ var delCommand = cli.Command{
 	Usage: "delete a cgroup",
 	Action: func(clix *cli.Context) error {
 		path := clix.Args().First()
-		c, err := cgroup2.LoadManager(clix.GlobalString("mountpoint"), path)
+		c, err := cgroup2.Load(path, cgroup2.WithMountpoint(clix.GlobalString("mountpoint")))
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ var listCommand = cli.Command{
 	Usage: "list processes in a cgroup",
 	Action: func(clix *cli.Context) error {
 		path := clix.Args().First()
-		c, err := cgroup2.LoadManager(clix.GlobalString("mountpoint"), path)
+		c, err := cgroup2.Load(path, cgroup2.WithMountpoint(clix.GlobalString("mountpoint")))
 		if err != nil {
 			return err
 		}
@@ -132,7 +132,7 @@ var listControllersCommand = cli.Command{
 	Usage: "list controllers in a cgroup",
 	Action: func(clix *cli.Context) error {
 		path := clix.Args().First()
-		c, err := cgroup2.LoadManager(clix.GlobalString("mountpoint"), path)
+		c, err := cgroup2.Load(path, cgroup2.WithMountpoint(clix.GlobalString("mountpoint")))
 		if err != nil {
 			return err
 		}
@@ -152,7 +152,7 @@ var statCommand = cli.Command{
 	Usage: "stat a cgroup",
 	Action: func(clix *cli.Context) error {
 		path := clix.Args().First()
-		c, err := cgroup2.LoadManager(clix.GlobalString("mountpoint"), path)
+		c, err := cgroup2.Load(path, cgroup2.WithMountpoint(clix.GlobalString("mountpoint")))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- cgroup1.Load's first parameter could be moved to functional options.
- cgroup2.LoadManager's first parameter could be moved too and Manager suffix doesn't make much sense.

Both changes make cgroup1.Load and cgroup2.Load much closer.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>