### PR TITLE
cg1: Clarify MemoryEvent comments

### DIFF
--- a/cgroup1/memory.go
+++ b/cgroup1/memory.go
@@ -43,7 +43,7 @@ type memoryThresholdEvent struct {
 	swap      bool
 }
 
-// MemoryThresholdEvent returns a new memory threshold event to be used with RegisterMemoryEvent.
+// MemoryThresholdEvent returns a new [MemoryEvent] representing the memory threshold set.
 // If swap is true, the event will be registered using memory.memsw.usage_in_bytes
 func MemoryThresholdEvent(threshold uint64, swap bool) MemoryEvent {
 	return &memoryThresholdEvent{
@@ -83,7 +83,7 @@ type memoryPressureEvent struct {
 	hierarchy     EventNotificationMode
 }
 
-// MemoryPressureEvent returns a new memory pressure event to be used with RegisterMemoryEvent.
+// MemoryPressureEvent returns a new [MemoryEvent] representing the memory pressure set.
 func MemoryPressureEvent(pressureLevel MemoryPressureLevel, hierarchy EventNotificationMode) MemoryEvent {
 	return &memoryPressureEvent{
 		pressureLevel,


### PR DESCRIPTION
Closing out https://github.com/containerd/cgroups/issues/188. Clarify that some of the functions in the cgroup1 package return `MemoryEvent` interfaces and not internal types.