### PR TITLE
cg2: syscall -> x/sys/unix

### DIFF
--- a/cgroup2/testutils_test.go
+++ b/cgroup2/testutils_test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,8 +27,8 @@ import (
 )
 
 func checkCgroupMode(t *testing.T) {
-	var st syscall.Statfs_t
-	if err := syscall.Statfs(defaultCgroup2Path, &st); err != nil {
+	var st unix.Statfs_t
+	if err := unix.Statfs(defaultCgroup2Path, &st); err != nil {
 		t.Fatal("cannot statfs cgroup root")
 	}
 	isUnified := st.Type == unix.CGROUP2_SUPER_MAGIC


### PR DESCRIPTION
Change to x/sys/unix definitions. I left cgroups 1 as right now it *should* be able to build on non-linux platforms, but there's a singular `syscall.EINVAL` check which swapping to unix would ruin. cg2 should already not be able to build on non-linux as we were using `InotifyInit` and `Statfs_t` in tests.