### PR TITLE
Use sync (bufferpool) to reduce allocation in controllers.

### DIFF
--- a/cgroup1/utils.go
+++ b/cgroup1/utils.go
@@ -18,7 +18,9 @@ package cgroup1
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -130,12 +132,18 @@ func hugePageSizes() ([]string, error) {
 	return pageSizes, nil
 }
 
-func readUint(path string) (uint64, error) {
-	v, err := os.ReadFile(path)
+func readUint(path string, buf *bytes.Buffer) (uint64, error) {
+	f, err := os.Open(path)
 	if err != nil {
 		return 0, err
 	}
-	return parseUint(strings.TrimSpace(string(v)), 10, 64)
+	defer f.Close()
+
+	_, err = io.Copy(buf, f)
+	if err != nil {
+		return 0, err
+	}
+	return parseUint(strings.TrimSpace(buf.String()), 10, 64)
 }
 
 func parseUint(s string, base, bitSize int) (uint64, error) {


### PR DESCRIPTION
ReadUint is modified to take a byteBuffer and the file contents
are copied into it. The buf sync pool is created at the controller
level so that it controller determines if it needs one.

Ran a benchmark on pids test.

Earlier:

goos: linux
goarch: amd64
pkg: github.com/containerd/cgroups/v3/cgroup1
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkPids-8   	   59758	     19905 ns/op	    2064 B/op	      15 allocs/op
PASS
ok  	github.com/containerd/cgroups/v3/cgroup1	1.405s

With this change:
goos: linux
goarch: amd64
pkg: github.com/containerd/cgroups/v3/cgroup1
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
BenchmarkPids-8   	   57368	     21665 ns/op	    1345 B/op	      13 allocs/op
PASS
ok  	github.com/containerd/cgroups/v3/cgroup1	1.467s

Inspired from: https://github.com/containerd/cgroups/pull/275

Signed-off-by: Manu Gupta <manugupt1@gmail.com>
