### PR TITLE
Reduce allocs in ReadUint64 by pre-allocating byte buffer

### DIFF
--- a/cgroup1/utils.go
+++ b/cgroup1/utils.go
@@ -131,11 +131,19 @@ func hugePageSizes() ([]string, error) {
 }
 
 func readUint(path string) (uint64, error) {
-	v, err := os.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return 0, err
 	}
-	return parseUint(strings.TrimSpace(string(v)), 10, 64)
+	defer f.Close()
+
+	b := make([]byte, 128) // Chose 128 as some files have leading/trailing whitespaces and alignment
+	n, err := f.Read(b)
+	if err != nil {
+		return 0, err
+	}
+
+	return parseUint(strings.TrimSpace(string(b[:n])), 10, 64)
 }
 
 func parseUint(s string, base, bitSize int) (uint64, error) {

--- a/cgroup1/utils_test.go
+++ b/cgroup1/utils_test.go
@@ -1,0 +1,32 @@
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package cgroup1
+
+import (
+	"testing"
+)
+
+func BenchmarkReaduint64(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := readUint("/proc/self/loginuid")
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
PR captures the reasoning behind this:
https://github.com/containerd/cgroups/pull/275/files#r1152562543


    Reduce allocs in ReadUint64 by pre-allocating byte buffer
    
    Before
    
    Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkReaduint64$ github.com/containerd/cgroups/v3/cgroup1 -count=1 -timeout 30m
    
    goos: linux
    goarch: amd64
    pkg: github.com/containerd/cgroups/v3/cgroup1
    cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
    BenchmarkReaduint64-8             105118              9762 ns/op             848 B/op          5 allocs/op
    PASS
    ok      github.com/containerd/cgroups/v3/cgroup1        1.151s
    
    After
    
    Running tool: /usr/local/go/bin/go test -benchmem -run=^$ -bench ^BenchmarkReaduint64$ github.com/containerd/cgroups/v3/cgroup1 -count=1 -timeout 30m
    
    goos: linux
    goarch: amd64
    pkg: github.com/containerd/cgroups/v3/cgroup1
    cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
    BenchmarkReaduint64-8             141484              8322 ns/op             128 B/op          3 allocs/op
    PASS
    ok      github.com/containerd/cgroups/v3/cgroup1        1.274s


