### PR TITLE
Cgroup2: Reduce allocations for `manager.Stat`

### DIFF
--- a/cgroup2/manager.go
+++ b/cgroup2/manager.go
@@ -523,7 +523,10 @@ func (c *Manager) Stat() (*stats.Metrics, error) {
 	if err != nil {
 		return nil, err
 	}
-	out := make(map[string]uint64)
+	// Sizing this avoids an allocation to increase the map at runtime;
+	// currently the default bucket size is 8 and we put 40+ elements
+	// in it so we'd always end up allocating.
+	out := make(map[string]uint64, 50)
 	for _, controller := range controllers {
 		switch controller {
 		case "cpu", "memory":
@@ -541,8 +544,8 @@ func (c *Manager) Stat() (*stats.Metrics, error) {
 			return nil, err
 		}
 	}
-	var metrics stats.Metrics
 
+	var metrics stats.Metrics
 	metrics.Pids = &stats.PidsStat{
 		Current: getStatFileContentUint64(filepath.Join(c.path, "pids.current")),
 		Limit:   getStatFileContentUint64(filepath.Join(c.path, "pids.max")),

--- a/cgroup2/manager_test.go
+++ b/cgroup2/manager_test.go
@@ -223,3 +223,20 @@ func TestCgroupType(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, cgType, Threaded)
 }
+
+func BenchmarkStat(b *testing.B) {
+	checkCgroupMode(b)
+	group := "/stat-test-cg"
+	groupPath := fmt.Sprintf("%s-%d", group, os.Getpid())
+	c, err := NewManager(defaultCgroup2Path, groupPath, &Resources{})
+	require.NoErrorf(b, err, "failed to init new cgroup manager")
+	b.Cleanup(func() {
+		_ = c.Delete()
+	})
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := c.Stat()
+		require.NoError(b, err)
+	}
+}

--- a/cgroup2/testutils_test.go
+++ b/cgroup2/testutils_test.go
@@ -27,14 +27,14 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func checkCgroupMode(t *testing.T) {
+func checkCgroupMode(tb testing.TB) {
 	var st unix.Statfs_t
 	err := unix.Statfs(defaultCgroup2Path, &st)
-	require.NoError(t, err, "cannot statfs cgroup root")
+	require.NoError(tb, err, "cannot statfs cgroup root")
 
 	isUnified := st.Type == unix.CGROUP2_SUPER_MAGIC
 	if !isUnified {
-		t.Skip("System running in hybrid or cgroupv1 mode")
+		tb.Skip("System running in hybrid or cgroupv1 mode")
 	}
 }
 

--- a/cgroup2/utils_test.go
+++ b/cgroup2/utils_test.go
@@ -58,3 +58,11 @@ func TestToResources(t *testing.T) {
 	v2resources2 := ToResources(&res2)
 	assert.Equal(t, CPUMax("max 10000"), v2resources2.CPU.Max)
 }
+
+func BenchmarkGetStatFileContentUint64(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_ = getStatFileContentUint64("/proc/self/loginuid")
+	}
+}


### PR DESCRIPTION
Related to https://github.com/containerd/cgroups/issues/280. There's still some spots we can fix, as the majority of allocs are occurring in bufio.Scan in readKVStatsFile. cc @kolyshkin @manugupt1 seeming as how we were all there for the last one 

This change works towards bringing down allocations for manager.Stat(). There's quite a few things we can do:

1. Swap to opening a file and issuing a single read for uint64/"max" values. Previously we were doing os.ReadFile's which returns a byte slice, so it needs to allocate.
2. Sizing the map we store {controller}.stat values in. We store 40+ stats in this map and the default bucket size for Go seems to be smaller than this, so we'd incur a couple allocs at runtime when adding these.
3. Finally, and funnily enough the biggest win, was just not calling f.Readdir(-1) for hugeTlb stats, and swapping this for a trick the runc cgroup code does. The number of allocs shaved off here is tied to the number of files in the cgroup directory
as f.Readdir(-1) was being called everytime we went to collect HugeTlb stats (it returns a slice of interfaces, that all we were doing is using the Name() method of anyways). To optimize this we can take advantage of the fact that we know exactly what files we need to open as they're fixed, the only variable portion is the hugepage sizes available on the host. To get around this we can compute the hugepage sizes in a sync.Once, and all future manager.Stat calls can reap the benefits as we don't need to Readdir() the entire cgroup path to search for hugetlb.pagesize.foobar's.

All in all on Go 1.19.4 this drops allocations in Stat from 322 to 198

```shell
benchstat ~/benchstat/old.txt ~/benchstat/new.txt 
goos: linux
goarch: amd64
pkg: github.com/containerd/cgroups/v3/cgroup2
cpu: AMD Ryzen 9 5900X 12-Core Processor            
        │ /home/dcantah/benchstat/old.txt │   /home/dcantah/benchstat/new.txt   │
        │             sec/op              │   sec/op     vs base                │
Stat-24                      112.29µ ± 3%   65.10µ ± 6%  -42.02% (p=0.000 n=10)

        │ /home/dcantah/benchstat/old.txt │   /home/dcantah/benchstat/new.txt    │
        │              B/op               │     B/op      vs base                │
Stat-24                      41.40Ki ± 0%   22.26Ki ± 0%  -46.23% (p=0.000 n=10)

        │ /home/dcantah/benchstat/old.txt │  /home/dcantah/benchstat/new.txt   │
        │            allocs/op            │ allocs/op   vs base                │
Stat-24                        322.0 ± 0%   198.0 ± 0%  -38.51% (p=0.000 n=10)
```

