### PR TITLE
Cgroup1: Lower buffer size for uint reads

### DIFF
--- a/cgroup1/utils.go
+++ b/cgroup1/utils.go
@@ -137,7 +137,9 @@ func readUint(path string) (uint64, error) {
 	}
 	defer f.Close()
 
-	b := make([]byte, 128) // Chose 128 as some files have leading/trailing whitespaces and alignment
+	// We should only need 20 bytes for the max uint64, but for a nice power of 2
+	// lets use 32.
+	b := make([]byte, 32)
 	n, err := f.Read(b)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This was partly a brain fart on my end during review for this, we should only need 20 bytes to handle reading the largest unsigned 64 bit integer (21 if we for some reason wanted to read the line feed that's in all of these files to). Lets use 32 for a nice power of two though.