### PR TITLE
Cgroup2: Testify all tests

### DIFF
--- a/cgroup2/cpuv2_test.go
+++ b/cgroup2/cpuv2_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCgroupv2CpuStats(t *testing.T) {
@@ -45,10 +46,10 @@ func TestCgroupv2CpuStats(t *testing.T) {
 		},
 	}
 	c, err := NewManager(defaultCgroup2Path, groupPath, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup manager: ", err)
-	}
-	defer os.Remove(c.path)
+	require.NoError(t, err, "failed to init new cgroup manager")
+	t.Cleanup(func() {
+		os.Remove(c.path)
+	})
 
 	checkFileContent(t, c.path, "cpu.weight", strconv.FormatUint(weight, 10))
 	checkFileContent(t, c.path, "cpu.max", max)
@@ -62,9 +63,8 @@ func TestSystemdCgroupCpuController(t *testing.T) {
 	var weight uint64 = 100
 	res := Resources{CPU: &CPU{Weight: &weight}}
 	c, err := NewSystemd("", group, os.Getpid(), &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup systemd manager: ", err)
-	}
+	require.NoError(t, err, "failed to init new cgroup systemd manager")
+
 	checkFileContent(t, c.path, "cpu.weight", strconv.FormatUint(weight, 10))
 }
 
@@ -82,9 +82,7 @@ func TestSystemdCgroupCpuController_NilWeight(t *testing.T) {
 		},
 	}
 	_, err := NewSystemd("/", group, -1, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup systemd manager: ", err)
-	}
+	require.NoError(t, err, "failed to init new cgroup systemd manager")
 }
 
 func TestExtractQuotaAndPeriod(t *testing.T) {

--- a/cgroup2/devicefilter_test.go
+++ b/cgroup2/devicefilter_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
 )
 
 func hash(s, comm string) string {
@@ -37,17 +38,14 @@ func hash(s, comm string) string {
 
 func testDeviceFilter(t testing.TB, devices []specs.LinuxDeviceCgroup, expectedStr string) {
 	insts, _, err := DeviceFilter(devices)
-	if err != nil {
-		t.Fatalf("%s: %v (devices: %+v)", t.Name(), err, devices)
-	}
+	require.NoErrorf(t, err, "%s: (devices: %+v)", t.Name(), devices)
+
 	s := insts.String()
 	t.Logf("%s: devices: %+v\n%s", t.Name(), devices, s)
 	if expectedStr != "" {
 		hashed := hash(s, "//")
 		expectedHashed := hash(expectedStr, "//")
-		if expectedHashed != hashed {
-			t.Fatalf("expected:\n%q\ngot\n%q", expectedHashed, hashed)
-		}
+		require.Equal(t, expectedHashed, hashed)
 	}
 }
 

--- a/cgroup2/hugetlbv2_test.go
+++ b/cgroup2/hugetlbv2_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCgroupv2HugetlbStats(t *testing.T) {
@@ -34,14 +35,14 @@ func TestCgroupv2HugetlbStats(t *testing.T) {
 		HugeTlb: &hugeTlb,
 	}
 	c, err := NewManager(defaultCgroup2Path, groupPath, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup manager: ", err)
-	}
-	defer os.Remove(c.path)
+	require.NoError(t, err, "failed to init new cgroup manager")
+	t.Cleanup(func() {
+		os.Remove(c.path)
+	})
+
 	stats, err := c.Stat()
-	if err != nil {
-		t.Fatal("failed to get cgroups stats: ", err)
-	}
+	require.NoError(t, err, "failed to get cgroup stats")
+
 	for _, entry := range stats.Hugetlb {
 		if entry.Pagesize == "2MB" {
 			assert.Equal(t, uint64(1073741824), entry.Max)

--- a/cgroup2/iov2_test.go
+++ b/cgroup2/iov2_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCgroupv2IOController(t *testing.T) {
@@ -39,10 +41,10 @@ func TestCgroupv2IOController(t *testing.T) {
 		},
 	}
 	c, err := NewManager(defaultCgroup2Path, groupPath, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup manager: ", err)
-	}
-	defer os.Remove(c.path)
+	require.NoError(t, err, "failed to init new cgroup manager")
+	t.Cleanup(func() {
+		os.Remove(c.path)
+	})
 
 	checkFileContent(t, c.path, "io.max", "8:0 rbps=max wbps=max riops=120 wiops=max")
 }

--- a/cgroup2/memoryv2_test.go
+++ b/cgroup2/memoryv2_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCgroupv2MemoryStats(t *testing.T) {
@@ -36,14 +37,13 @@ func TestCgroupv2MemoryStats(t *testing.T) {
 		},
 	}
 	c, err := NewManager(defaultCgroup2Path, groupPath, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup manager: ", err)
-	}
-	defer os.Remove(c.path)
+	require.NoError(t, err, "failed to init new cgroup manager")
+	t.Cleanup(func() {
+		os.Remove(c.path)
+	})
+
 	stats, err := c.Stat()
-	if err != nil {
-		t.Fatal("failed to get cgroups stats: ", err)
-	}
+	require.NoError(t, err, "failed to get cgroup stats")
 
 	assert.Equal(t, uint64(314572800), stats.Memory.SwapLimit)
 	assert.Equal(t, uint64(629145600), stats.Memory.UsageLimit)
@@ -61,9 +61,8 @@ func TestSystemdCgroupMemoryController(t *testing.T) {
 		},
 	}
 	c, err := NewSystemd("", group, os.Getpid(), &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup systemd manager: ", err)
-	}
+	require.NoError(t, err, "failed to init new cgroup systemd manager")
+
 	checkFileContent(t, c.path, "memory.min", "16384")
 	checkFileContent(t, c.path, "memory.max", "629145600")
 }

--- a/cgroup2/paths_test.go
+++ b/cgroup2/paths_test.go
@@ -18,6 +18,8 @@ package cgroup2
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVerifyGroupPath(t *testing.T) {
@@ -34,13 +36,9 @@ func TestVerifyGroupPath(t *testing.T) {
 	for s, valid := range valids {
 		err := VerifyGroupPath(s)
 		if valid {
-			if err != nil {
-				t.Error(err)
-			}
+			assert.NoError(t, err)
 		} else {
-			if err == nil {
-				t.Error("error is expected")
-			}
+			assert.Error(t, err)
 		}
 	}
 }

--- a/cgroup2/pidsv2_test.go
+++ b/cgroup2/pidsv2_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCgroupv2PidsStats(t *testing.T) {
@@ -34,10 +36,10 @@ func TestCgroupv2PidsStats(t *testing.T) {
 		},
 	}
 	c, err := NewManager(defaultCgroup2Path, groupPath, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup manager: ", err)
-	}
-	defer os.Remove(c.path)
+	require.NoError(t, err, "failed to init new cgroup manager")
+	t.Cleanup(func() {
+		os.Remove(c.path)
+	})
 
 	checkFileContent(t, c.path, "pids.max", strconv.Itoa(int(max)))
 }
@@ -48,8 +50,7 @@ func TestSystemdCgroupPidsController(t *testing.T) {
 	pid := os.Getpid()
 	res := Resources{}
 	c, err := NewSystemd("", group, pid, &res)
-	if err != nil {
-		t.Fatal("failed to init new cgroup systemd manager: ", err)
-	}
+	require.NoError(t, err, "failed to init new cgroup systemd manager")
+
 	checkFileContent(t, c.path, "cgroup.procs", strconv.Itoa(pid))
 }

--- a/cgroup2/testutils_test.go
+++ b/cgroup2/testutils_test.go
@@ -23,14 +23,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
 func checkCgroupMode(t *testing.T) {
 	var st unix.Statfs_t
-	if err := unix.Statfs(defaultCgroup2Path, &st); err != nil {
-		t.Fatal("cannot statfs cgroup root")
-	}
+	err := unix.Statfs(defaultCgroup2Path, &st)
+	require.NoError(t, err, "cannot statfs cgroup root")
+
 	isUnified := st.Type == unix.CGROUP2_SUPER_MAGIC
 	if !isUnified {
 		t.Skip("System running in hybrid or cgroupv1 mode")
@@ -46,8 +47,6 @@ func checkCgroupControllerSupported(t *testing.T, controller string) {
 
 func checkFileContent(t *testing.T, path, filename, value string) {
 	out, err := os.ReadFile(filepath.Join(path, filename))
-	if err != nil {
-		t.Fatalf("failed to read %s file", filename)
-	}
+	require.NoErrorf(t, err, "failed to read %s file", filename)
 	assert.Equal(t, value, strings.TrimSpace(string(out)))
 }

--- a/cgroup2/utils_test.go
+++ b/cgroup2/utils_test.go
@@ -33,16 +33,10 @@ func TestParseCgroupFromReader(t *testing.T) {
 	for s, expected := range cases {
 		g, err := parseCgroupFromReader(strings.NewReader(s))
 		if expected != "" {
-			if g != expected {
-				t.Errorf("expected %q, got %q", expected, g)
-			}
-			if err != nil {
-				t.Error(err)
-			}
+			assert.Equal(t, g, expected)
+			assert.NoError(t, err)
 		} else {
-			if err == nil {
-				t.Error("error is expected")
-			}
+			assert.Error(t, err)
 		}
 	}
 }


### PR DESCRIPTION
Use require/assert for all the cgroup2 tests. These tests were in a weird spot where some of them used a mix of testify.assert, and some used `testify.require` in place of `if err != nil { t.Fatal() }`. This just moves everything over to `require.NoError` and friends.