### PR TITLE
Improve performance by for pid stats (cgroups1) re-using readuint

### DIFF
--- a/cgroup1/pids.go
+++ b/cgroup1/pids.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -67,15 +66,9 @@ func (p *pidsController) Stat(path string, stats *v1.Metrics) error {
 	if err != nil {
 		return err
 	}
-	var max uint64
-	maxData, err := os.ReadFile(filepath.Join(p.Path(path), "pids.max"))
+	max, err := readUint(filepath.Join(p.Path(path), "pids.max"))
 	if err != nil {
 		return err
-	}
-	if maxS := strings.TrimSpace(string(maxData)); maxS != "max" {
-		if max, err = parseUint(maxS, 10, 64); err != nil {
-			return err
-		}
 	}
 	stats.Pids = &v1.PidsStat{
 		Current: current,

--- a/cgroup1/utils_test.go
+++ b/cgroup1/utils_test.go
@@ -17,6 +17,8 @@
 package cgroup1
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -28,5 +30,22 @@ func BenchmarkReaduint64(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
+	}
+}
+
+func TestReadUint(t *testing.T) {
+	tDir := t.TempDir()
+	pidsmax := filepath.Join(tDir, "pids.max")
+	err := os.WriteFile(pidsmax, []byte("max"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	max, err := readUint(pidsmax)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// test for backwards compatibility
+	if max != 0 {
+		t.Fail()
 	}
 }


### PR DESCRIPTION
cc @kolyshkin @dcantah 

I re-used the optimized readuint in cgroups to improve performance. This should not change the behavior for max as readuint returns 0 and when a file is not present; an error is still returned.

PTAL

Benchstat results:


```
➜  cgroups git:(main) ✗ benchstat old.txt new.txt
goos: linux
goarch: amd64
pkg: github.com/containerd/cgroups/v3/cgroup1
cpu: 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
           │   old.txt   │              new.txt               │
           │   sec/op    │   sec/op     vs base               │
TestPids-8   19.32µ ± 4%   17.39µ ± 2%  -9.97% (p=0.000 n=10)

           │   old.txt   │              new.txt               │
           │    B/op     │    B/op     vs base                │
TestPids-8   1344.0 ± 0%   624.0 ± 0%  -53.57% (p=0.000 n=10)

           │  old.txt   │              new.txt               │
           │ allocs/op  │ allocs/op   vs base                │
TestPids-8   13.00 ± 0%   11.00 ± 0%  -15.38% (p=0.000 n=10)
➜  cgroups git:(main) ✗
```