### PR TITLE
cgroup2: only enable the cpuset controller if cpus or mems is specified

### DIFF
--- a/cgroup2/manager.go
+++ b/cgroup2/manager.go
@@ -96,7 +96,9 @@ func (r *Resources) Values() (o []Value) {
 func (r *Resources) EnabledControllers() (c []string) {
 	if r.CPU != nil {
 		c = append(c, "cpu")
-		c = append(c, "cpuset")
+		if r.CPU.Cpus != "" || r.CPU.Mems != "" {
+			c = append(c, "cpuset")
+		}
 	}
 	if r.Memory != nil {
 		c = append(c, "memory")


### PR DESCRIPTION
try fixes: #292