### PR TITLE
cgroup1 delete: proceed to the next subsystem when a cgroup is not found

### DIFF
--- a/cgroup1/cgroup.go
+++ b/cgroup1/cgroup.go
@@ -41,7 +41,7 @@ func New(path Path, resources *specs.LinuxResources, opts ...InitOpts) (Cgroup, 
 			return nil, err
 		}
 	}
-	subsystems, err := config.hiearchy()
+	subsystems, err := config.hierarchy()
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func Load(path Path, opts ...InitOpts) (Cgroup, error) {
 		}
 	}
 	var activeSubsystems []Subsystem
-	subsystems, err := config.hiearchy()
+	subsystems, err := config.hierarchy()
 	if err != nil {
 		return nil, err
 	}

--- a/cgroup1/cgroup.go
+++ b/cgroup1/cgroup.go
@@ -259,6 +259,10 @@ func (c *cgroup) Delete() error {
 		// kernel prevents cgroups with running process from being removed, check the tree is empty
 		procs, err := c.processes(s.Name(), true, cgroupProcs)
 		if err != nil {
+			// if the control group does not exist within a subsystem, then proceed to the next subsystem
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return err
 		}
 		if len(procs) > 0 {

--- a/cgroup1/cgroup_test.go
+++ b/cgroup1/cgroup_test.go
@@ -459,6 +459,13 @@ func TestDelete(t *testing.T) {
 		t.Error(err)
 		return
 	}
+
+	err = mock.symLink()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	if err := control.Delete(); err != nil {
 		t.Error(err)
 	}

--- a/cgroup1/mock_test.go
+++ b/cgroup1/mock_test.go
@@ -73,3 +73,21 @@ func (m *mockCgroup) delete() error {
 func (m *mockCgroup) hierarchy() ([]Subsystem, error) {
 	return m.subsystems, nil
 }
+
+// symLink() creates a symlink between net_cls and net_prio for testing
+// On certain Linux systems, there's a symlink from both net_cls and net_prio to "net_cls,net_prio"
+// Since we don't have a subsystem defined for "net_cls,net_prio",
+// we mock this behavior by creating a symlink directly between net_cls and net_prio
+func (m *mockCgroup) symLink() error {
+	netCLS := filepath.Join(m.root, string(NetCLS))
+	netPrio := filepath.Join(m.root, string(NetPrio))
+	// remove netCLS before creating a symlink
+	if err := os.RemoveAll(netCLS); err != nil {
+		return err
+	}
+	// create symlink between net_cls and net_prio
+	if err := os.Symlink(netPrio, netCLS); err != nil {
+		return err
+	}
+	return nil
+}

--- a/cgroup1/opts.go
+++ b/cgroup1/opts.go
@@ -36,13 +36,13 @@ type InitOpts func(*InitConfig) error
 type InitConfig struct {
 	// InitCheck can be used to check initialization errors from the subsystem
 	InitCheck InitCheck
-	hiearchy  Hierarchy
+	hierarchy Hierarchy
 }
 
 func newInitConfig() *InitConfig {
 	return &InitConfig{
 		InitCheck: RequireDevices,
-		hiearchy:  Default,
+		hierarchy: Default,
 	}
 }
 
@@ -66,7 +66,7 @@ func RequireDevices(s Subsystem, _ Path, _ error) error {
 // The default list is coming from /proc/self/mountinfo.
 func WithHiearchy(h Hierarchy) InitOpts {
 	return func(c *InitConfig) error {
-		c.hiearchy = h
+		c.hierarchy = h
 		return nil
 	}
 }

--- a/cgroup1/v1.go
+++ b/cgroup1/v1.go
@@ -45,7 +45,7 @@ func Default() ([]Subsystem, error) {
 }
 
 // v1MountPoint returns the mount point where the cgroup
-// mountpoints are mounted in a single hiearchy
+// mountpoints are mounted in a single hierarchy
 func v1MountPoint() (string, error) {
 	f, err := os.Open("/proc/self/mountinfo")
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Anuj Singh <singholt@amazon.com>

The cgroup1 Delete method checks for running processes within each subsystem, before deleting the cgroup from it. 

I noticed that there are cases when removing a cgroup from one subsystem, also removes it from others.
For example, on Amazon Linux (kernel 4.14), removing a cgroup from `net_cls` subsystem also removes the cgroup from `net_prio`. This is because both `net_cls` and `net_prio` have a symlink to a common dir `net_cls, net_prio`. Similarly, removing a cgroup from `cpu` also removes it from the `cpuacct` subsystem, because of a symlink to `cpu,cpuacct`.

```
ls -l /sys/fs/cgroup/net_cls /sys/fs/cgroup/net_prio
/sys/fs/cgroup/net_cls -> net_cls,net_prio
/sys/fs/cgroup/net_prio -> net_cls,net_prio 
```

In such a case the Delete() errors out with an error like 

```
lstat /sys/fs/cgroup/net_prio/test: no such file or directory
```

Sample code: https://gist.github.com/singholt/2a600802c0f74c8acdacd247760dc291 that fails on the Delete() without this fix but passes with it.

This change handles the above case, when a query to get cgroup processes within a subsystem returns a `fs.ErrNotExist`. In such a case, we move to the next subsystem, instead of erroring out of the Delete() immediately. This ensures that the cgroup is deleted from all subsystems that have it.

As per cgroups v1 [documentation](https://man7.org/linux/man-pages/man7/cgroups.7.html#CGROUPS_VERSION_1), since files in a cgroup directory cannot and need not be removed, it is safe to assume that if `cgroup.procs` doesn't exist for a cgroup (within a subsystem), the cgroup has been removed from the subsystem.

This PR has two commits - first addressing the problem above, with the unit test updated and second, just fixing a typo.