### PR TITLE
fix(): support re-enabling oom killer refs #307

### DIFF
--- a/cgroup1/memory.go
+++ b/cgroup1/memory.go
@@ -454,6 +454,9 @@ func getOomControlValue(mem *specs.LinuxMemory) *int64 {
 	if mem.DisableOOMKiller != nil && *mem.DisableOOMKiller {
 		i := int64(1)
 		return &i
+	} else if mem.DisableOOMKiller != nil && !*mem.DisableOOMKiller {
+		i := int64(0)
+		return &i
 	}
 	return nil
 }


### PR DESCRIPTION
DisableOOMKiller will be ignored if it is false, which will result in oomkiller being unable to be re-enabled after this setting is disabled.