### PR TITLE
Linux.Swap is defined as memory+swap combined, while in cgroup v2 swap is a separate value

### DIFF
--- a/cgroup2/utils.go
+++ b/cgroup2/utils.go
@@ -176,6 +176,10 @@ func ToResources(spec *specs.LinuxResources) *Resources {
 		resources.Memory = &Memory{}
 		if swap := mem.Swap; swap != nil {
 			resources.Memory.Swap = swap
+			if l := mem.Limit; l != nil {
+				reduce := *swap - *l
+				resources.Memory.Swap = &reduce
+			}
 		}
 		if l := mem.Limit; l != nil {
 			resources.Memory.Max = l

--- a/cgroup2/utils_test.go
+++ b/cgroup2/utils_test.go
@@ -46,13 +46,20 @@ func TestToResources(t *testing.T) {
 		quota  int64  = 8000
 		period uint64 = 10000
 		shares uint64 = 5000
+
+		mem  int64 = 300
+		swap int64 = 500
 	)
 	weight := 1 + ((shares-2)*9999)/262142
-	res := specs.LinuxResources{CPU: &specs.LinuxCPU{Quota: &quota, Period: &period, Shares: &shares}}
+	res := specs.LinuxResources{
+		CPU:    &specs.LinuxCPU{Quota: &quota, Period: &period, Shares: &shares},
+		Memory: &specs.LinuxMemory{Limit: &mem, Swap: &swap},
+	}
 	v2resources := ToResources(&res)
 
 	assert.Equal(t, weight, *v2resources.CPU.Weight)
 	assert.Equal(t, CPUMax("8000 10000"), v2resources.CPU.Max)
+	assert.Equal(t, swap-mem, *v2resources.Memory.Swap)
 
 	res2 := specs.LinuxResources{CPU: &specs.LinuxCPU{Period: &period}}
 	v2resources2 := ToResources(&res2)


### PR DESCRIPTION
fix： https://github.com/containerd/cgroups/issues/309