### PR TITLE
cg2: Don't read cgroup.procs when deleting threaded cg

### DIFF
--- a/cgroup2/manager_test.go
+++ b/cgroup2/manager_test.go
@@ -284,7 +284,7 @@ func TestCgroupType(t *testing.T) {
 	manager, err := NewManager(defaultCgroup2Path, "/test-type", ToResources(&specs.LinuxResources{}))
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		os.RemoveAll(manager.path)
+		_ = manager.Delete()
 	})
 
 	cgType, err := manager.GetType()


### PR DESCRIPTION
Reading cgroup.procs seems to return ENOTSUPP when threaded, so check the type of the cg when going to delete and read the relevant file.