### PR TITLE
rename misspelling WithHiearchy to WithHierarchy

### DIFF
--- a/Protobuild.toml
+++ b/Protobuild.toml
@@ -13,7 +13,7 @@ generators = ["go"]
   # This is the default.
   after = ["/usr/local/include", "/usr/include"]
 
-# Aggregrate the API descriptors to lock down API changes.
+# Aggregate the API descriptors to lock down API changes.
 [[descriptors]]
 prefix = "github.com/containerd/cgroups/cgroup1/stats"
 target = "cgroup1/stats/metrics.pb.txt"

--- a/cgroup1/cgroup_test.go
+++ b/cgroup1/cgroup_test.go
@@ -38,7 +38,7 @@ func TestCreate(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -69,7 +69,7 @@ func TestStat(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -95,7 +95,7 @@ func TestAdd(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -122,7 +122,7 @@ func TestAddFilteredSubsystems(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -183,7 +183,7 @@ func TestAddTask(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -210,7 +210,7 @@ func TestAddTaskFilteredSubsystems(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -256,7 +256,7 @@ func TestListPids(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -295,7 +295,7 @@ func TestListTasksPids(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -386,7 +386,7 @@ func TestLoad(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -396,7 +396,7 @@ func TestLoad(t *testing.T) {
 			t.Errorf("failed to delete cgroup: %v", err)
 		}
 	}()
-	if control, err = Load(StaticPath("test"), WithHiearchy(mock.hierarchy)); err != nil {
+	if control, err = Load(StaticPath("test"), WithHierarchy(mock.hierarchy)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -430,7 +430,7 @@ func TestLoadWithMissingSubsystems(t *testing.T) {
 		t.Error("control is nil")
 		return
 	}
-	if control, err = Load(StaticPath("test"), WithHiearchy(mock.hierarchy)); err != nil {
+	if control, err = Load(StaticPath("test"), WithHierarchy(mock.hierarchy)); err != nil {
 		t.Error(err)
 		return
 	}
@@ -454,7 +454,7 @@ func TestDelete(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -481,7 +481,7 @@ func TestCreateSubCgroup(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -523,7 +523,7 @@ func TestFreezeThaw(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -556,7 +556,7 @@ func TestSubsystems(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("test"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return
@@ -583,7 +583,7 @@ func TestCpusetParent(t *testing.T) {
 			t.Errorf("failed delete: %v", err)
 		}
 	}()
-	control, err := New(StaticPath("/parent/child"), &specs.LinuxResources{}, WithHiearchy(mock.hierarchy))
+	control, err := New(StaticPath("/parent/child"), &specs.LinuxResources{}, WithHierarchy(mock.hierarchy))
 	if err != nil {
 		t.Error(err)
 		return

--- a/cgroup1/opts.go
+++ b/cgroup1/opts.go
@@ -62,11 +62,19 @@ func RequireDevices(s Subsystem, _ Path, _ error) error {
 	return ErrIgnoreSubsystem
 }
 
-// WithHiearchy sets a list of cgroup subsystems.
+// WithHierarchy sets a list of cgroup subsystems.
 // The default list is coming from /proc/self/mountinfo.
-func WithHiearchy(h Hierarchy) InitOpts {
+func WithHierarchy(h Hierarchy) InitOpts {
 	return func(c *InitConfig) error {
 		c.hierarchy = h
 		return nil
 	}
+}
+
+// WithHiearchy sets a list of cgroup subsystems. It is just kept for backward
+// compatibility and will be removed in v4.
+//
+// Deprecated: use WithHierarchy instead.
+func WithHiearchy(h Hierarchy) InitOpts {
+	return WithHierarchy(h)
 }

--- a/cgroup1/utils.go
+++ b/cgroup1/utils.go
@@ -236,9 +236,9 @@ func getCgroupDestination(subsystem string) (string, error) {
 	return "", ErrNoCgroupMountDestination
 }
 
-func pathers(subystems []Subsystem) []pather {
+func pathers(subsystems []Subsystem) []pather {
 	var out []pather
-	for _, s := range subystems {
+	for _, s := range subsystems {
 		if p, ok := s.(pather); ok {
 			out = append(out, p)
 		}

--- a/cgroup2/devicefilter.go
+++ b/cgroup2/devicefilter.go
@@ -14,7 +14,7 @@
    limitations under the License.
 */
 
-// Devicefilter containes eBPF device filter program
+// Devicefilter contains eBPF device filter program
 //
 // The implementation is based on https://github.com/containers/crun/blob/0.10.2/src/libcrun/ebpf.c
 //

--- a/cgroup2/manager.go
+++ b/cgroup2/manager.go
@@ -317,7 +317,7 @@ func (c *Manager) ToggleControllers(controllers []string, t ControllerToggle) er
 		}
 		filePath := filepath.Join(f, subtreeControl)
 		if err := c.writeSubtreeControl(filePath, controllers, t); err != nil {
-			// When running as rootless, the user may face EPERM on parent groups, but it is neglible when the
+			// When running as rootless, the user may face EPERM on parent groups, but it is negligible when the
 			// controller is already written.
 			// So we only return the last error.
 			lastErr = fmt.Errorf("failed to write subtree controllers %+v to %q: %w", controllers, filePath, err)


### PR DESCRIPTION
Rename the misspelling method `WithHiearchy` to the correct version, and mark `WithHiearchy` deprecated.

Some other minor typo fixes are also included.

Close: https://github.com/containerd/cgroups/issues/320