### PR TITLE
chore: don't log ENOTSUP during parsing PSI files

### DIFF
--- a/cgroup2/utils.go
+++ b/cgroup2/utils.go
@@ -514,7 +514,9 @@ func getStatPSIFromFile(path string) *stats.PSIStats {
 	}
 
 	if err := sc.Err(); err != nil {
-		logrus.Errorf("unable to parse PSI data: %v", err)
+		if !errors.Is(err, unix.ENOTSUP) {
+			logrus.Errorf("unable to parse PSI data: %v", err)
+		}
 		return nil
 	}
 	return psistats


### PR DESCRIPTION
Currently, the PSI parsing code records error logs when PSI is disabled.
This update ensures that only error logs are recorded, except when the error is `unix.ENOTSUP`.

Other Projects:
- https://github.com/moby/buildkit/pull/3999
- https://github.com/opencontainers/runc/pull/3900#issuecomment-1589690845