### PR TITLE
Add `EOPNOTSUPP` to err filter for PSI data

### DIFF
--- a/cgroup2/utils.go
+++ b/cgroup2/utils.go
@@ -514,7 +514,7 @@ func getStatPSIFromFile(path string) *stats.PSIStats {
 	}
 
 	if err := sc.Err(); err != nil {
-		if !errors.Is(err, unix.ENOTSUP) {
+		if !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, unix.EOPNOTSUPP) {
 			logrus.Errorf("unable to parse PSI data: %v", err)
 		}
 		return nil


### PR DESCRIPTION
When PSI is not enabled, the file reads will end up in `Operation not supported` error. Here is the relevant strace

```
mmap(NULL, 139264, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x154ea7496000
read(3, 0x154ea7497000, 131072)         = -1 EOPNOTSUPP (Operation not supported)
```

This PR adds `EOPNOTSUPP` to filter as well besides `ENOTSUP`.