### PR TITLE
Update golangci-lint action to v4 and linter to v1.57.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,9 @@ jobs:
           cache-dependency-path: src/github.com/containerd/cgroups
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.51.1
+          version: v1.57.1
           args: --verbose
           working-directory: src/github.com/containerd/cgroups
 


### PR DESCRIPTION
### Issue
CI is failing for linter errors

### Description
This change updates golangci-lint GitHub action package to v4 and linter version to v1.57.1