### PR TITLE
Add dependabot automation for GitHub Actions packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+  interval: "weekly"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
### Issue
GitHub Actions packages are showing deprecation warnings in CI. The update to resolve is simple enough for automation to keep these packages up-to-date.

![image](https://github.com/containerd/cgroups/assets/55906459/7d5b39b3-6263-41f3-814a-97492bdfeb87)

### Description
This change adds dependabot automation configuration for GitHub Actions packages on a weekly cadence.