### PR TITLE
fix(ci): fix broken dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
-package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-  interval: "weekly"
-  open-pull-requests-limit: 10
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
#331 introduces dependabot on Github Actions but has a wrong format. This PR will fix the broken workflow.

See: [Keeping your actions up to date with Dependabot - Github](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot)