### PR TITLE
group1: don't use deprecated ParseCgroupFileUnified internally

### DIFF
--- a/cgroup1/utils.go
+++ b/cgroup1/utils.go
@@ -196,7 +196,7 @@ func parseKV(raw string) (string, uint64, error) {
 // The resulting map does not have an element for cgroup v2 unified hierarchy.
 // Use [cgroups.ParseCgroupFileUnified] to get the unified path.
 func ParseCgroupFile(path string) (map[string]string, error) {
-	x, _, err := ParseCgroupFileUnified(path)
+	x, _, err := cgroups.ParseCgroupFileUnified(path)
 	return x, err
 }
 


### PR DESCRIPTION
Don't call this function internally to make it easier to see when it becomes unused.