### PR TITLE
rename/remove vars that collided with builtin, minor linting and cleanup

### DIFF
--- a/cgroup1/pids.go
+++ b/cgroup1/pids.go
@@ -66,13 +66,13 @@ func (p *pidsController) Stat(path string, stats *v1.Metrics) error {
 	if err != nil {
 		return err
 	}
-	max, err := readUint(filepath.Join(p.Path(path), "pids.max"))
+	pidsMax, err := readUint(filepath.Join(p.Path(path), "pids.max"))
 	if err != nil {
 		return err
 	}
 	stats.Pids = &v1.PidsStat{
 		Current: current,
-		Limit:   max,
+		Limit:   pidsMax,
 	}
 	return nil
 }

--- a/cgroup2/cpuv2_test.go
+++ b/cgroup2/cpuv2_test.go
@@ -36,23 +36,22 @@ func TestCgroupv2CpuStats(t *testing.T) {
 		period uint64 = 8000
 		weight uint64 = 100
 	)
-	max := "10000 8000"
-	res := Resources{
+
+	c, err := NewManager(defaultCgroup2Path, groupPath, &Resources{
 		CPU: &CPU{
 			Weight: &weight,
 			Max:    NewCPUMax(&quota, &period),
 			Cpus:   "0",
 			Mems:   "0",
 		},
-	}
-	c, err := NewManager(defaultCgroup2Path, groupPath, &res)
+	})
 	require.NoError(t, err, "failed to init new cgroup manager")
 	t.Cleanup(func() {
-		os.Remove(c.path)
+		_ = os.Remove(c.path)
 	})
 
 	checkFileContent(t, c.path, "cpu.weight", strconv.FormatUint(weight, 10))
-	checkFileContent(t, c.path, "cpu.max", max)
+	checkFileContent(t, c.path, "cpu.max", "10000 8000")
 	checkFileContent(t, c.path, "cpuset.cpus", "0")
 	checkFileContent(t, c.path, "cpuset.mems", "0")
 }
@@ -61,8 +60,7 @@ func TestSystemdCgroupCpuController(t *testing.T) {
 	checkCgroupMode(t)
 	group := fmt.Sprintf("testing-cpu-%d.scope", os.Getpid())
 	var weight uint64 = 100
-	res := Resources{CPU: &CPU{Weight: &weight}}
-	c, err := NewSystemd("", group, os.Getpid(), &res)
+	c, err := NewSystemd("", group, os.Getpid(), &Resources{CPU: &CPU{Weight: &weight}})
 	require.NoError(t, err, "failed to init new cgroup systemd manager")
 
 	checkFileContent(t, c.path, "cpu.weight", strconv.FormatUint(weight, 10))
@@ -75,13 +73,12 @@ func TestSystemdCgroupCpuController_NilWeight(t *testing.T) {
 	var quota int64 = 10000
 	var period uint64 = 8000
 	cpuMax := NewCPUMax(&quota, &period)
-	res := Resources{
+	_, err := NewSystemd("/", group, -1, &Resources{
 		CPU: &CPU{
 			Weight: nil,
 			Max:    cpuMax,
 		},
-	}
-	_, err := NewSystemd("/", group, -1, &res)
+	})
 	require.NoError(t, err, "failed to init new cgroup systemd manager")
 }
 


### PR DESCRIPTION
- remove / rename `max` variables, as that's now a builtin
- inline some variables
- suppress an unhandled error in a t.Cleanup