### PR TITLE
go.mod: update to go1.19 as minimum, and add go1.22.x to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.20.x'
+          go-version: '1.22.x'
           cache-dependency-path: src/github.com/containerd/cgroups
 
       - name: Project checks
@@ -50,7 +50,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.21.x, 1.22.x]
 
     steps:
       - name: Checkout cgroups
@@ -78,7 +78,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.19.x, 1.21.x, 1.22.x]
         # Ubuntu-20.04 has cgroups v1 default; Ubuntu-22.04 has cgroups v2 default.
         os: [ubuntu-20.04, ubuntu-22.04]
 

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/cgroups/cmd
 
-go 1.18
+go 1.19
 
 replace github.com/containerd/cgroups/v3 => ../
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/containerd/cgroups/v3
 
-go 1.18
+go 1.19
 
 require (
 	github.com/cilium/ebpf v0.11.0


### PR DESCRIPTION
### go.mod: update to go1.19 as minimum

This is the oldest version tested in CI, so set this as the
minimum version.


### gha: also test on go1.22.x