### PR TITLE
fix: use the specified go version in lint jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.go-version }}
           cache-dependency-path: src/github.com/containerd/cgroups
 
       - name: golangci-lint
@@ -92,7 +92,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ matrix.go-version }}
           # Disable Go caching feature when compiling across Linux distributions due to collisions until https://github.com/actions/setup-go/issues/368 is resolved.
           cache: false
 


### PR DESCRIPTION
Ref #351

Due to a typo in the workflow the lint jobs where installing the latest version of go, rather then the one specified.