### PR TITLE
group1: cpusetController.getValues: don't use naked returns

### DIFF
--- a/cgroup1/cpuset.go
+++ b/cgroup1/cpuset.go
@@ -86,11 +86,13 @@ func (c *cpusetController) Update(path string, resources *specs.LinuxResources) 
 }
 
 func (c *cpusetController) getValues(path string) (cpus []byte, mems []byte, err error) {
-	if cpus, err = os.ReadFile(filepath.Join(path, "cpuset.cpus")); err != nil && !os.IsNotExist(err) {
-		return
+	cpus, err = os.ReadFile(filepath.Join(path, "cpuset.cpus"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
 	}
-	if mems, err = os.ReadFile(filepath.Join(path, "cpuset.mems")); err != nil && !os.IsNotExist(err) {
-		return
+	mems, err = os.ReadFile(filepath.Join(path, "cpuset.mems"))
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, err
 	}
 	return cpus, mems, nil
 }


### PR DESCRIPTION
Explicitly return nil instead of potentially returning a partial result (only cpus or mems). Also re-format the code to prevent these variables being confused for local to the if branch.