### PR TITLE
cgroup2: Manager.Delete: handle both "threaded" and "domain threaded"

### DIFF
--- a/cgroup2/manager.go
+++ b/cgroup2/manager.go
@@ -472,10 +472,6 @@ func (c *Manager) fallbackKill() error {
 }
 
 func (c *Manager) Delete() error {
-	var (
-		tasks    []uint64
-		threaded bool
-	)
 	// Kernel prevents cgroups with running process from being removed,
 	// check the tree is empty.
 	//
@@ -485,13 +481,13 @@ func (c *Manager) Delete() error {
 		if !os.IsNotExist(err) {
 			return err
 		}
-	} else {
-		threaded = cgType == Threaded
 	}
 
-	if threaded {
+	var tasks []uint64
+	switch cgType {
+	case Threaded, DomainThreaded:
 		tasks, err = c.Threads(true)
-	} else {
+	default:
 		tasks, err = c.Procs(true)
 	}
 	if err != nil {


### PR DESCRIPTION
- relates to https://github.com/containerd/cgroups/pull/318
- relates to https://github.com/containerd/cgroups/pull/324


commit 6f5001dbae8ec248caad9b86c07c869f10ec5726 added special handling for threaded cgroup types. A later contribution added detection for "domain threaded" as known type, but did not update the handling to detect this type.

From the original PR;

> Reading cgroup.procs seems to return ENOTSUPP when threaded, so check
> the type of the cg when going to delete and read the relevant file.

An alternative could be to check both variants unconditionally, and to error if either Manager.Threads or Manager.Procs is non-zero.