### PR TITLE
Add cgroupV2 CPUQuotaPeriodUSec support

### DIFF
--- a/cgroup2/manager.go
+++ b/cgroup2/manager.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/cgroups/v3/cgroup2/stats"
@@ -45,9 +46,17 @@ const (
 	typeFile           = "cgroup.type"
 	defaultCgroup2Path = "/sys/fs/cgroup"
 	defaultSlice       = "system.slice"
+
+	// systemd only supports CPUQuotaPeriodUSec since v2.42.0
+	cpuQuotaPeriodUSecSupportedVersion = 242
 )
 
-var canDelegate bool
+var (
+	canDelegate bool
+
+	versionOnce sync.Once
+	version     int
+)
 
 type Event struct {
 	Low     uint64
@@ -875,7 +884,19 @@ func NewSystemd(slice, group string, pid int, resources *Resources) (*Manager, e
 	}
 
 	if resources.CPU != nil && resources.CPU.Max != "" {
-		quota, period := resources.CPU.Max.extractQuotaAndPeriod()
+		quota, period, err := resources.CPU.Max.extractQuotaAndPeriod()
+		if err != nil {
+			return &Manager{}, err
+		}
+
+		if period != 0 {
+			if sdVer := systemdVersion(conn); sdVer >= cpuQuotaPeriodUSecSupportedVersion {
+				properties = append(properties, newSystemdProperty("CPUQuotaPeriodUSec", period))
+			} else {
+				log.G(context.TODO()).WithField("version", sdVer).Debug("Systemd version is too old to support CPUQuotaPeriodUSec")
+			}
+		}
+
 		// cpu.cfs_quota_us and cpu.cfs_period_us are controlled by systemd.
 		// corresponds to USEC_INFINITY in systemd
 		// if USEC_INFINITY is provided, CPUQuota is left unbound by systemd
@@ -913,6 +934,41 @@ func NewSystemd(slice, group string, pid int, resources *Resources) (*Manager, e
 	return &Manager{
 		path: path,
 	}, nil
+}
+
+// Adapted from https://github.com/opencontainers/cgroups/blob/9657f5a18b8d60a0f39fbb34d0cb7771e28e6278/systemd/common.go#L245-L281
+func systemdVersion(conn *systemdDbus.Conn) int {
+	versionOnce.Do(func() {
+		version = -1
+		verStr, err := conn.GetManagerProperty("Version")
+		if err == nil {
+			version, err = systemdVersionAtoi(verStr)
+		}
+
+		if err != nil {
+			log.G(context.TODO()).WithError(err).Error("Unable to get systemd version")
+		}
+	})
+
+	return version
+}
+
+func systemdVersionAtoi(str string) (int, error) {
+	// Unconditionally remove the leading prefix ("v).
+	str = strings.TrimLeft(str, `"v`)
+	// Match on the first integer we can grab.
+	for i := range len(str) {
+		if str[i] < '0' || str[i] > '9' {
+			// First non-digit: cut the tail.
+			str = str[:i]
+			break
+		}
+	}
+	ver, err := strconv.Atoi(str)
+	if err != nil {
+		return -1, fmt.Errorf("can't parse version: %w", err)
+	}
+	return ver, nil
 }
 
 func startUnit(conn *systemdDbus.Conn, group string, properties []systemdDbus.Property, ignoreExists bool) error {

--- a/cgroup2/testutils_test.go
+++ b/cgroup2/testutils_test.go
@@ -17,11 +17,13 @@
 package cgroup2
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	systemdDbus "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -35,6 +37,16 @@ func checkCgroupMode(tb testing.TB) {
 	isUnified := st.Type == unix.CGROUP2_SUPER_MAGIC
 	if !isUnified {
 		tb.Skip("System running in hybrid or cgroupv1 mode")
+	}
+}
+
+func requireSystemdVersion(tb testing.TB, requiredMinVersion int) {
+	conn, err := systemdDbus.NewWithContext(context.TODO())
+	require.NoError(tb, err, "failed to connect to systemd")
+	defer conn.Close()
+
+	if sdVer := systemdVersion(conn); sdVer < requiredMinVersion {
+		tb.Skipf("Skipping test; systemd version %d < required version %d", sdVer, requiredMinVersion)
 	}
 }
 


### PR DESCRIPTION
Addresses https://github.com/containerd/cgroups/issues/365

This change adds `CPUQuotaPeriodUSec` property for cgroupsv2. Heavily influenced by github.com/opencontainers/cgroups. Refactors a bit of the existing functions for testability.

Added some unit tests for validating the property is properly set.
