### PR TITLE
Swap cgroupsv1 testing from GitHub Actions runner to Vagrant VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,18 +71,91 @@ jobs:
           args: --verbose
           working-directory: src/github.com/containerd/cgroups
 
-  test:
-    name: Test cgroups
+  cgroupV1:
+    name: Cgroup V1 tests
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     needs: [project]
 
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.22.x, 1.23.x]
-        # Ubuntu-20.04 has cgroups v1 default; Ubuntu-22.04 has cgroups v2 default.
-        os: [ubuntu-20.04, ubuntu-22.04]
 
-    runs-on: ${{ matrix.os }}
+    env:
+      BOX: almalinux/8
+      GO_VERSION: ${{ matrix.go-version }}
+
+    steps:
+      - name: Show the host info
+        run: |
+          set -x
+          uname -a
+          cat /etc/os-release
+          cat /proc/cpuinfo
+          free -mt
+
+      - name: Checkout cgroups
+        uses: actions/checkout@v4
+        with:
+          path: src/github.com/containerd/cgroups
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Set Go version
+        run: |
+          go_version=$(go version | grep -oP 'go\d+\.\d+\.\d+' | sed -E 's/go([0-9]+)\.([0-9]+)\.([0-9]+)/\1\.\2\.\3/')
+          echo "GO_VERSION=$go_version" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        with:
+          path: /root/.vagrant.d
+          key: vagrant-${{ env.BOX }}
+
+      - name: Set up vagrant
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update
+          sudo apt-get install -y libvirt-daemon libvirt-daemon-system vagrant ovmf
+
+          # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1725#issuecomment-1454058646
+          sudo cp /usr/share/OVMF/OVMF_VARS_4M.fd /var/lib/libvirt/qemu/nvram/
+          sudo systemctl enable --now libvirtd
+          sudo apt-get build-dep -y ruby-libvirt
+          sudo apt-get install -y --no-install-recommends libxslt-dev libxml2-dev libvirt-dev ruby-bundler ruby-dev zlib1g-dev
+
+          if ! vagrant plugin list | grep -q vagrant-libvirt; then
+            sudo env VAGRANT_DISABLE_STRICT_DEPENDENCY_ENFORCEMENT=1 vagrant plugin install vagrant-libvirt
+          fi
+
+      - name: Boot VM
+        working-directory: src/github.com/containerd/cgroups
+        run: sudo BOX=$BOX GO_VERSION=$GO_VERSION vagrant up --provision-with=install-packages,setup-etc-environment,install-golang,setup-gopath
+
+      - name: Run cgroup tests
+        working-directory: src/github.com/containerd/cgroups
+        run: sudo BOX=$BOX GO_VERSION=$GO_VERSION vagrant up --provision-with=test
+
+      - name: Build cgctl
+        working-directory: src/github.com/containerd/cgroups
+        run: sudo BOX=$BOX GO_VERSION=$GO_VERSION vagrant up --provision-with=build-cgctl
+
+  cgroupV2:
+    name: Cgroup V2 tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    needs: [project]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.22.x, 1.23.x]
+
     steps:
       - name: Checkout cgroups
         uses: actions/checkout@v4
@@ -93,8 +166,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-          # Disable Go caching feature when compiling across Linux distributions due to collisions until https://github.com/actions/setup-go/issues/368 is resolved.
-          cache: false
 
       - name: Run cgroup tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
   #
   project:
     name: Project Checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
 
     steps:
@@ -46,7 +46,7 @@ jobs:
     name: Lint
     timeout-minutes: 10
     needs: [project]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:
@@ -107,7 +107,7 @@ jobs:
 
   proto:
     name: Compare auto-generated Go files
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout cgroups

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,143 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+#   Copyright The containerd Authors.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+Vagrant.configure("2") do |config|
+  config.vm.box = ENV["BOX"] ? ENV["BOX"].split("@")[0] : "almalinux/8"
+  # BOX_VERSION is deprecated. Use "BOX=<BOX>@<BOX_VERSION>".
+  config.vm.box_version = ENV["BOX_VERSION"] || (ENV["BOX"].split("@")[1] if ENV["BOX"])
+
+  memory = 4096
+  cpus = 2
+  disk_size = 60
+  config.vm.provider :virtualbox do |v, o|
+    v.memory = memory
+    v.cpus = cpus
+    # Needs env var VAGRANT_EXPERIMENTAL="disks"
+    o.vm.disk :disk, size: "#{disk_size}GB", primary: true
+    v.customize ["modifyvm", :id, "--firmware", "efi"]
+  end
+  config.vm.provider :libvirt do |v|
+    v.memory = memory
+    v.cpus = cpus
+    v.machine_virtual_size = disk_size
+    # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/1725#issuecomment-1454058646
+    # Needs `sudo cp /usr/share/OVMF/OVMF_VARS_4M.fd /var/lib/libvirt/qemu/nvram/`
+    v.loader = '/usr/share/OVMF/OVMF_CODE_4M.fd'
+    v.nvram = '/var/lib/libvirt/qemu/nvram/OVMF_VARS_4M.fd'
+  end
+
+  config.vm.synced_folder ".", "/vagrant", type: "rsync"
+
+  config.vm.provision 'shell', path: 'script/resize-vagrant-root.sh'
+
+  # To re-run, installing CNI from RPM:
+  #   INSTALL_PACKAGES="containernetworking-plugins" vagrant up --provision-with=install-packages
+  #
+  config.vm.provision "install-packages", type: "shell", run: "once" do |sh|
+    sh.upload_path = "/tmp/vagrant-install-packages"
+    sh.env = {
+        'INSTALL_PACKAGES': ENV['INSTALL_PACKAGES'],
+    }
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        dnf -y install \
+            curl \
+            gcc \
+            git \
+            make \
+            ${INSTALL_PACKAGES}
+    SHELL
+  end
+
+  # AlmaLinux does not have /usr/local/{bin,sbin} in the PATH by default
+  config.vm.provision "setup-etc-environment", type: "shell", run: "once" do |sh|
+    sh.upload_path = "/tmp/vagrant-setup-etc-environment"
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        cat >> /etc/environment <<EOF
+PATH=/usr/local/go/bin:/usr/local/bin:/usr/local/sbin:$PATH
+EOF
+        source /etc/environment
+        SHELL
+  end
+
+  # To re-run this provisioner, installing a different version of go:
+  #   GO_VERSION="1.14.6" vagrant up --provision-with=install-golang
+  #
+  config.vm.provision "install-golang", type: "shell", run: "once" do |sh|
+    sh.upload_path = "/tmp/vagrant-install-golang"
+    sh.env = {
+        'GO_VERSION': ENV['GO_VERSION'] || "1.24.3",
+    }
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        set -eux -o pipefail
+        curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar Cxz /usr/local
+        cat >> /etc/profile.d/sh.local <<EOF
+GOPATH=\\$HOME/go
+PATH=\\$GOPATH/bin:\\$PATH
+export GOPATH PATH
+git config --global --add safe.directory /vagrant
+EOF
+    source /etc/profile.d/sh.local
+    SHELL
+  end
+
+  config.vm.provision "setup-gopath", type: "shell", run: "once" do |sh|
+    sh.upload_path = "/tmp/vagrant-setup-gopath"
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        source /etc/environment
+        source /etc/profile.d/sh.local
+        set -eux -o pipefail
+        mkdir -p ${GOPATH}/src/github.com/containerd
+        ln -fnsv /vagrant ${GOPATH}/src/github.com/containerd/cgroups
+    SHELL
+  end
+
+  config.vm.provision "test", type: "shell", run: "never" do |sh|
+    sh.upload_path = "/tmp/test"
+    sh.env = {
+        'GOTEST': ENV['GOTEST'] || "go test",
+        'GOTESTSUM_JUNITFILE': ENV['GOTESTSUM_JUNITFILE'],
+        'GOTESTSUM_JSONFILE': ENV['GOTESTSUM_JSONFILE'],
+    }
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        source /etc/environment
+        source /etc/profile.d/sh.local
+        set -eux -o pipefail
+        cd ${GOPATH}/src/github.com/containerd/cgroups
+        go env -w CGO_ENABLED=1
+        go test -exec "sudo" -v -race -coverprofile=coverage.txt -covermode=atomic ./...
+    SHELL
+  end
+
+  config.vm.provision "build-cgctl", type: "shell", run: "never" do |sh|
+    sh.upload_path = "/tmp/build-cgctl"
+    sh.inline = <<~SHELL
+        #!/usr/bin/env bash
+        source /etc/environment
+        source /etc/profile.d/sh.local
+        set -eux -o pipefail
+        cd ${GOPATH}/src/github.com/containerd/cgroups
+        make all
+    SHELL
+  end
+end

--- a/script/resize-vagrant-root.sh
+++ b/script/resize-vagrant-root.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+#   Copyright The containerd Authors.
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+set -eu -o pipefail
+
+# Rocky Linux doesn't have growpart by default.
+(growpart -h > /dev/null) || dnf -y install cloud-utils-growpart
+
+df_line=$(df -T / | grep '^/dev/')
+if [[ "$df_line" =~ ^/dev/([a-z]+)([0-9]+) ]]; then
+    dev="${BASH_REMATCH[1]}"
+    part="${BASH_REMATCH[2]}"
+    growpart "/dev/$dev" "$part"
+
+    fstype=$(echo "$df_line" | awk '{print $2}')
+    if [[ "$fstype" = 'btrfs' ]]; then
+        btrfs filesystem resize max /
+    elif [[ "$fstype" = 'xfs' ]]; then
+        xfs_growfs -d /
+    else
+        echo "Unknown filesystem: $df_line"
+        exit 1
+    fi
+elif [[ "$df_line" =~ ^/dev/mapper/ ]]; then
+    echo "TODO: support device mapper: $df_line"
+else
+    echo "Failed to parse: $df_line"
+    exit 1
+fi


### PR DESCRIPTION
This pull request includes CI updates for cgroup v1 testing by swapping from Ubuntu 20 GitHub Actions runners to AlmaLinux/8 Vagrant VMs. This is needed because the cgroup v1 GitHub Actions runners went end-of-life in April 2025.